### PR TITLE
Add Qt UI harnesses and spec-compliant tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+        python-version: ["3.11"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest pytest-asyncio pytest-qt
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Open-source Python toolkit for working with FMV BAPS Realtime TSPI v4 telemetry.
 ## Features
 - **Producer** – UDP listener that parses TSPI datagrams, adds receive timestamps, and publishes CBOR payloads to JetStream with deduplication headers.
 - **Receiver** – Durable JetStream consumer that decodes CBOR, validates against the Draft 2020-12 schema, and emits JSON lines or logs.
-- **JetStream Player** – Qt5 application (GUI/headless) with rate control, seek scaffolding, metrics reporting, and room-based playout subjects.
+- **JetStream Player** – Qt5 application (GUI/headless) with rate control, seek scaffolding, metrics reporting, and room-based playout subjects backed by smoothed map previews.
 - **PCAP Player** – Replays 37-byte TSPI frames from pcap/pcapng files into the UDP producer with adjustable rate, loop, and headless metrics.
-- **TSPI Generator** – Synthetic flight track generator (normal or airshow) targeting UDP or JetStream outputs with configurable fleet size/rates.
+- **TSPI Generator** – Synthetic flight track generator (normal or airshow) targeting UDP or JetStream outputs with configurable fleet size/rates and headless automation.
 - **Schema & Tests** – Draft 2020-12 schema (`tspi.schema.json`) and pytest suite covering datagram parsing and schema validation.
 
 ## Getting Started
@@ -81,7 +81,7 @@ The Draft 2020-12 schema in `tspi.schema.json` enforces shared fields (`type`, `
 ```bash
 pytest
 ```
-Tests cover datagram parsing for both message types and schema validation. Add `pytest-qt` driven UI tests once GUI widgets are implemented.
+Tests cover datagram parsing for both message types, schema validation, non-UI integration flows, and Qt5 GUI/headless behaviour. Run `pytest -k ui` to focus on interface validation driven by `pytest-qt`.
 
 ## Offline Maps
 Map previews currently use placeholder widgets. Final integration will use PyQtWebEngine/OSM tiles with configurable smoothing (`--smooth-center`, `--smooth-zoom`, `--window-sec`) exposed via shared UI configuration (`tspi_kit.ui.app.UiConfig`). Headless modes remain fully operational without map assets.

--- a/pcap_player_qt.py
+++ b/pcap_player_qt.py
@@ -1,0 +1,52 @@
+"""Entry point for the PCAP Player."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from PyQt5 import QtWidgets
+
+from tspi_kit.pcap import PCAPReplayer
+from tspi_kit.producer import TSPIProducer
+from tspi_kit.ui import PCAPPlayerController
+from tspi_kit.ui.player import connect_in_memory, ensure_offscreen
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PCAP Player")
+    parser.add_argument("--pcap", type=Path, required=True)
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--rate", type=float, default=1.0)
+    parser.add_argument("--loop", action="store_true")
+    parser.add_argument("--metrics-interval", type=float, default=1.0)
+    parser.add_argument("--stdout-json", action="store_true", default=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ensure_offscreen(args.headless)
+    stream, receiver = connect_in_memory()
+    producer = TSPIProducer(stream)
+    replayer = PCAPReplayer(args.pcap)
+    controller = PCAPPlayerController(replayer, producer, rate=args.rate, loop=args.loop)
+
+    if args.headless:
+        controller.replay()
+        return 0
+
+    app = QtWidgets.QApplication(sys.argv)
+    window = QtWidgets.QWidget()
+    window.setWindowTitle("PCAP Player")
+    layout = QtWidgets.QVBoxLayout(window)
+    label = QtWidgets.QLabel("PCAP Player Ready", window)
+    layout.addWidget(label)
+    window.show()
+    controller.metrics_updated.connect(lambda payload: label.setText(payload))
+    controller.replay()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/player_qt.py
+++ b/player_qt.py
@@ -1,0 +1,53 @@
+"""Entry point for the JetStream Player Qt application."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from PyQt5 import QtWidgets
+
+from tspi_kit.ui import HeadlessPlayerRunner, JetStreamPlayerWindow, UiConfig
+from tspi_kit.ui.player import connect_in_memory, ensure_offscreen
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="JetStream Player")
+    parser.add_argument("--headless", action="store_true", help="Run without a GUI")
+    parser.add_argument("--metrics-interval", type=float, default=1.0)
+    parser.add_argument("--duration", type=float)
+    parser.add_argument("--exit-on-idle", type=float)
+    parser.add_argument("--stdout-json", action="store_true", default=True)
+    parser.add_argument("--write-cbor", type=Path)
+    parser.add_argument("--rate", type=float, default=1.0)
+    parser.add_argument("--room", type=str, default="default")
+    parser.add_argument("--clock", choices=["receive", "tspi"], default="receive")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = UiConfig(metrics_interval=args.metrics_interval, default_rate=args.rate, default_clock=args.clock)
+    ensure_offscreen(args.headless)
+    stream, receiver = connect_in_memory()
+
+    if args.headless:
+        runner = HeadlessPlayerRunner(
+            receiver,
+            ui_config=config,
+            stdout_json=args.stdout_json,
+            duration=args.duration,
+            exit_on_idle=args.exit_on_idle,
+            write_cbor_dir=args.write_cbor,
+        )
+        runner.run()
+        return 0
+
+    app = QtWidgets.QApplication(sys.argv)
+    window = JetStreamPlayerWindow(receiver, ui_config=config)
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,5 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic
+PyQt5==5.15.11
+pytest-qt==4.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for ensuring package imports."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_OPENGL", "software")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_datagrams.py
+++ b/tests/test_datagrams.py
@@ -1,0 +1,195 @@
+"""Tests for parsing TSPI datagrams."""
+
+import struct
+
+import pytest
+
+from tspi_kit.datagrams import ParsedTSPI, parse_tspi_datagram
+from tspi_kit.jetstream import build_subject, message_headers
+from tspi_kit.schema import validate_payload
+
+_HEADER_FORMAT = ">BBHHIBH"
+_HEADER_SIZE = struct.calcsize(_HEADER_FORMAT)
+
+
+def _build_header(
+    *,
+    message_type: int,
+    sensor_id: int,
+    day: int,
+    time_ticks: int,
+    status: int,
+    status_flags: int,
+) -> bytes:
+    return struct.pack(
+        _HEADER_FORMAT,
+        message_type,
+        4,  # BAPS TSPI v4
+        sensor_id,
+        day,
+        time_ticks,
+        status,
+        status_flags,
+    )
+
+
+def _combine(header: bytes, payload: bytes) -> bytes:
+    datagram = header + payload
+    assert len(datagram) == 37
+    return datagram
+
+
+def _validate(parsed: ParsedTSPI) -> None:
+    payload = {
+        "type": parsed.type,
+        "sensor_id": parsed.sensor_id,
+        "day": parsed.day,
+        "time_s": parsed.time_s,
+        "status": parsed.status,
+        "status_flags": parsed.status_flags,
+        "recv_epoch_ms": 1_700_000_000_000,
+        "recv_iso": "2024-03-20T00:00:00+00:00",
+        "payload": parsed.payload,
+    }
+    validate_payload(payload)
+
+
+def test_parse_geocentric_datagram() -> None:
+    header = _build_header(
+        message_type=0xC1,
+        sensor_id=501,
+        day=123,
+        time_ticks=15340,
+        status=0xFF,
+        status_flags=0b0000_0000_0000_0001,
+    )
+    payload = struct.pack(
+        ">iii hhh hhh".replace(" ", ""),
+        round(5123.25 * 100),
+        round(-15.5 * 100),
+        round(1200.0 * 100),
+        round(12.34 * 100),
+        round(-5.67 * 100),
+        round(0.0 * 100),
+        round(0.12 * 100),
+        round(-0.34 * 100),
+        round(0.56 * 100),
+    )
+
+    datagram = _combine(header, payload)
+    parsed = parse_tspi_datagram(datagram)
+
+    assert parsed.type == "geocentric"
+    assert parsed.sensor_id == 501
+    assert parsed.day == 123
+    assert pytest.approx(parsed.time_s, rel=1e-9) == 1.534
+    assert parsed.status == 0xFF
+    assert parsed.status_flags == {
+        "position_x_valid": True,
+        "position_y_valid": True,
+        "position_z_valid": True,
+        "velocity_x_valid": True,
+        "velocity_y_valid": True,
+        "velocity_z_valid": True,
+        "acceleration_x_valid": True,
+        "acceleration_y_valid": True,
+        "acceleration_z_valid": True,
+    }
+    assert parsed.payload == {
+        "x_m": pytest.approx(5123.25),
+        "y_m": pytest.approx(-15.5),
+        "z_m": pytest.approx(1200.0),
+        "vx_mps": pytest.approx(12.34),
+        "vy_mps": pytest.approx(-5.67),
+        "vz_mps": pytest.approx(0.0),
+        "ax_mps2": pytest.approx(0.12),
+        "ay_mps2": pytest.approx(-0.34),
+        "az_mps2": pytest.approx(0.56),
+    }
+    assert parsed.deduplication_id() == "501:123:15340"
+    assert build_subject(parsed) == "tspi.geocentric.501"
+    assert message_headers(parsed) == {"Nats-Msg-Id": "501:123:15340"}
+
+    _validate(parsed)
+
+
+def test_parse_spherical_datagram() -> None:
+    header = _build_header(
+        message_type=0xC2,
+        sensor_id=2048,
+        day=42,
+        time_ticks=923400,
+        status=0b0000_1110,
+        status_flags=0b0000_0000_0000_0111,
+    )
+    payload = struct.pack(
+        ">iII hhh hhh".replace(" ", ""),
+        round(3800.0 * 100),
+        round(52.123456 * 1_000_000),
+        round(10.654321 * 1_000_000),
+        round(1.23 * 100),
+        round(-4.56 * 100),
+        round(7.89 * 100),
+        round(0.12 * 100),
+        round(-0.34 * 100),
+        round(0.56 * 100),
+    )
+
+    datagram = _combine(header, payload)
+    parsed = parse_tspi_datagram(datagram)
+
+    assert parsed.type == "spherical"
+    assert parsed.sensor_id == 2048
+    assert parsed.day == 42
+    assert pytest.approx(parsed.time_s, rel=1e-9) == 92.34
+    assert parsed.status_flags["position_x_valid"] is False
+    assert parsed.status_flags["velocity_x_valid"] is True
+    assert parsed.payload == {
+        "range_m": pytest.approx(3800.0),
+        "azimuth_deg": pytest.approx(52.123456),
+        "elevation_deg": pytest.approx(10.654321),
+        "azimuth_rate_dps": pytest.approx(1.23),
+        "elevation_rate_dps": pytest.approx(-4.56),
+        "range_rate_mps": pytest.approx(7.89),
+        "azimuth_accel_dps2": pytest.approx(0.12),
+        "elevation_accel_dps2": pytest.approx(-0.34),
+        "range_accel_mps2": pytest.approx(0.56),
+    }
+    assert parsed.deduplication_id() == "2048:42:923400"
+    assert build_subject(parsed, stream_prefix="custom") == "custom.spherical.2048"
+
+    _validate(parsed)
+
+
+def test_invalid_length() -> None:
+    header = _build_header(
+        message_type=0xC1,
+        sensor_id=1,
+        day=1,
+        time_ticks=0,
+        status=0,
+        status_flags=0,
+    )
+    payload = struct.pack(">iii hhh hhh".replace(" ", ""), *([0] * 9))
+
+    datagram = header + payload + b"extra"
+    with pytest.raises(ValueError):
+        parse_tspi_datagram(datagram)
+
+
+def test_invalid_version() -> None:
+    header = struct.pack(
+        _HEADER_FORMAT,
+        0xC1,
+        3,  # unsupported version
+        1,
+        1,
+        0,
+        0,
+        0,
+    )
+    payload = struct.pack(">iii hhh hhh".replace(" ", ""), *([0] * 9))
+    datagram = header + payload
+
+    with pytest.raises(ValueError):
+        parse_tspi_datagram(datagram)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,243 @@
+"""Integration tests exercising the Codex Spec Kit pipeline."""
+from __future__ import annotations
+
+import math
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import dpkt
+import pytest
+
+from tspi_kit import (
+    FlightConfig,
+    InMemoryJetStream,
+    InMemoryJetStreamCluster,
+    PCAPReplayer,
+    TSPIFlightGenerator,
+    TSPIProducer,
+    TSPIReceiver,
+)
+
+
+def _build_geocentric_datagram(
+    *,
+    sensor_id: int,
+    day: int,
+    time_ticks: int,
+    position: tuple[float, float, float],
+    velocity: tuple[float, float, float],
+    acceleration: tuple[float, float, float],
+    status: int = 0xFF,
+    status_flags: int = 0x01,
+) -> bytes:
+    import struct
+
+    header = struct.pack(
+        ">BBHHIBH",
+        0xC1,
+        4,
+        sensor_id,
+        day,
+        time_ticks,
+        status,
+        status_flags,
+    )
+    payload = struct.pack(
+        ">iii hhh hhh".replace(" ", ""),
+        int(position[0] * 100),
+        int(position[1] * 100),
+        int(position[2] * 100),
+        int(velocity[0] * 100),
+        int(velocity[1] * 100),
+        int(velocity[2] * 100),
+        int(acceleration[0] * 100),
+        int(acceleration[1] * 100),
+        int(acceleration[2] * 100),
+    )
+    return header + payload
+
+
+def _create_pipeline(jetstream=None):
+    jetstream = jetstream or InMemoryJetStream()
+    producer = TSPIProducer(jetstream)
+    consumer = jetstream.create_consumer("tspi.>")
+    receiver = TSPIReceiver(consumer)
+    return jetstream, producer, receiver
+
+
+def test_pcap_pipeline_round_trip() -> None:
+    jetstream, producer, receiver = _create_pipeline()
+
+    datagrams = [
+        _build_geocentric_datagram(
+            sensor_id=101,
+            day=123,
+            time_ticks=1000,
+            position=(100.0, 200.0, 300.0),
+            velocity=(10.0, -5.0, 0.5),
+            acceleration=(0.1, -0.1, 0.0),
+        ),
+        _build_geocentric_datagram(
+            sensor_id=102,
+            day=123,
+            time_ticks=1500,
+            position=(150.0, 250.0, 350.0),
+            velocity=(12.0, -4.0, 0.6),
+            acceleration=(0.2, -0.2, 0.1),
+        ),
+    ]
+
+    with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as handle:
+        writer = dpkt.pcap.Writer(handle, linktype=147)
+        writer.writepkt(b"invalid", ts=0.0)
+        for index, datagram in enumerate(datagrams):
+            writer.writepkt(datagram, ts=float(index) * 0.5)
+        path = Path(handle.name)
+
+    replayer = PCAPReplayer(path)
+    base_epoch = 1_700_000_000.0
+    replayer.replay(producer, rate=2.0, base_epoch=base_epoch)
+
+    try:
+        messages = receiver.fetch_all()
+        assert len(messages) == len(datagrams)
+
+        for index, payload in enumerate(messages):
+            assert payload["type"] == "geocentric"
+            assert payload["sensor_id"] == 101 + index
+            assert payload["payload"]["x_m"] == pytest.approx(100.0 + 50.0 * index)
+
+            delta_capture = index * 0.5
+            expected_recv = base_epoch + delta_capture / 2.0
+            expected_ms = int(round(expected_recv * 1000))
+            assert payload["recv_epoch_ms"] == expected_ms
+            iso = datetime.fromtimestamp(expected_recv, tz=timezone.utc).isoformat()
+            assert payload["recv_iso"] == iso
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_generator_pipeline_throughput_and_ranges() -> None:
+    jetstream, producer, receiver = _create_pipeline()
+    config = FlightConfig(count=5, rate_hz=20.0, speed_min_mps=60.0, speed_max_mps=120.0)
+    generator = TSPIFlightGenerator(config)
+
+    generator.stream_to_producer(producer, duration_seconds=0.5, base_epoch=1_700_000_100.0)
+
+    messages = receiver.fetch_all()
+    assert len(messages) == int(config.count * config.rate_hz * 0.5)
+
+    magnitudes = [
+        math.sqrt(
+            m["payload"]["vx_mps"] ** 2
+            + m["payload"]["vy_mps"] ** 2
+            + m["payload"]["vz_mps"] ** 2
+        )
+        for m in messages
+    ]
+    assert min(magnitudes) >= config.speed_min_mps - 1
+    assert max(magnitudes) <= config.speed_max_mps + 1
+
+    time_values = [m["time_s"] for m in messages]
+    assert all(time_values[i] <= time_values[i + 1] for i in range(len(time_values) - 1))
+
+
+def test_deduplication_enforced() -> None:
+    jetstream, producer, receiver = _create_pipeline()
+    datagram = _build_geocentric_datagram(
+        sensor_id=301,
+        day=200,
+        time_ticks=5000,
+        position=(1.0, 2.0, 3.0),
+        velocity=(0.1, 0.2, 0.3),
+        acceleration=(0.01, 0.02, 0.03),
+    )
+
+    first = producer.ingest(datagram, recv_time=1_700_000_200.0)
+    second = producer.ingest(datagram, recv_time=1_700_000_201.0)
+
+    messages = receiver.fetch_all()
+    assert len(messages) == 1
+    assert messages[0]["sensor_id"] == 301
+
+
+def test_replay_seek_monotonicity() -> None:
+    jetstream, producer, receiver = _create_pipeline()
+
+    for index in range(5):
+        datagram = _build_geocentric_datagram(
+            sensor_id=400 + index,
+            day=50,
+            time_ticks=1_000 + index * 250,
+            position=(0.0, 0.0, 0.0),
+            velocity=(10.0, 0.0, 0.0),
+            acceleration=(0.0, 0.0, 0.0),
+        )
+        producer.ingest(datagram, recv_time=1_700_000_300.0 + index)
+
+    messages = receiver.fetch_all()
+    seek_start = 0.15
+    replay_window = [m for m in messages if m["time_s"] >= seek_start]
+    assert replay_window
+    assert replay_window[0]["time_s"] >= seek_start
+    assert [m["time_s"] for m in replay_window] == sorted(m["time_s"] for m in replay_window)
+
+
+def test_cluster_failover_continuity() -> None:
+    cluster = InMemoryJetStreamCluster(replicas=3)
+    producer = TSPIProducer(cluster)
+    consumer = cluster.create_consumer("tspi.>")
+    receiver = TSPIReceiver(consumer)
+
+    for index in range(3):
+        datagram = _build_geocentric_datagram(
+            sensor_id=600 + index,
+            day=10,
+            time_ticks=2_000 + index * 100,
+            position=(index * 10.0, 0.0, 1000.0),
+            velocity=(50.0, 0.0, 0.0),
+            acceleration=(0.0, 0.0, 0.0),
+        )
+        producer.ingest(datagram, recv_time=1_700_000_400.0 + index)
+
+    cluster.kill_leader()
+
+    for index in range(3, 6):
+        datagram = _build_geocentric_datagram(
+            sensor_id=600 + index,
+            day=10,
+            time_ticks=2_000 + index * 100,
+            position=(index * 10.0, 0.0, 1000.0),
+            velocity=(50.0, 0.0, 0.0),
+            acceleration=(0.0, 0.0, 0.0),
+        )
+        producer.ingest(datagram, recv_time=1_700_000_400.0 + index)
+
+    messages = receiver.fetch_all()
+    assert len(messages) == 6
+    assert messages[0]["sensor_id"] == 600
+    assert messages[-1]["sensor_id"] == 605
+
+
+def test_back_pressure_metrics() -> None:
+    jetstream = InMemoryJetStream()
+    producer = TSPIProducer(jetstream)
+    consumer = jetstream.create_consumer("tspi.>")
+
+    for index in range(20):
+        updated = _build_geocentric_datagram(
+            sensor_id=900,
+            day=5,
+            time_ticks=10_000 + index * 10_000,
+            position=(0.0, 0.0, 1000.0),
+            velocity=(5.0, 0.0, 0.0),
+            acceleration=(0.0, 0.0, 0.0),
+        )
+        producer.ingest(updated, recv_time=1_700_000_500.0 + index)
+
+    assert consumer.pending() == 20
+
+    receiver = TSPIReceiver(consumer)
+    receiver.fetch(batch=5)
+    assert consumer.pending() == 15

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,81 @@
+"""Schema behaviour for TSPI payloads."""
+
+import pytest
+from jsonschema import ValidationError
+
+from tspi_kit.schema import load_schema, validate_payload
+
+
+def _status_flags(all_valid: bool = True) -> dict:
+    value = bool(all_valid)
+    return {
+        "position_x_valid": value,
+        "position_y_valid": value,
+        "position_z_valid": value,
+        "velocity_x_valid": value,
+        "velocity_y_valid": value,
+        "velocity_z_valid": value,
+        "acceleration_x_valid": value,
+        "acceleration_y_valid": value,
+        "acceleration_z_valid": value,
+    }
+
+
+def _base_payload() -> dict:
+    return {
+        "type": "geocentric",
+        "sensor_id": 10,
+        "day": 12,
+        "time_s": 1.25,
+        "status": 5,
+        "status_flags": _status_flags(),
+        "recv_epoch_ms": 1_694_761_234,
+        "recv_iso": "2024-01-01T12:34:56.789000+00:00",
+        "payload": {
+            "x_m": 0.0,
+            "y_m": 0.0,
+            "z_m": 0.0,
+            "vx_mps": 0.0,
+            "vy_mps": 0.0,
+            "vz_mps": 0.0,
+            "ax_mps2": 0.0,
+            "ay_mps2": 0.0,
+            "az_mps2": 0.0,
+        },
+    }
+
+
+def test_schema_metadata() -> None:
+    schema = load_schema()
+    assert schema["$schema"].endswith("2020-12/schema")
+    assert schema["properties"]["type"]["enum"] == ["geocentric", "spherical"]
+
+
+def test_validate_geocentric_payload() -> None:
+    payload = _base_payload()
+    validate_payload(payload)
+
+
+def test_validate_spherical_payload() -> None:
+    payload = _base_payload()
+    payload["type"] = "spherical"
+    payload["payload"] = {
+        "range_m": 123.0,
+        "azimuth_deg": 0.1,
+        "elevation_deg": -0.05,
+        "azimuth_rate_dps": 0.0,
+        "elevation_rate_dps": 0.0,
+        "range_rate_mps": 0.0,
+        "azimuth_accel_dps2": 0.0,
+        "elevation_accel_dps2": 0.0,
+        "range_accel_mps2": 0.0,
+    }
+    validate_payload(payload)
+
+
+def test_missing_field_raises_validation_error() -> None:
+    payload = _base_payload()
+    del payload["payload"]
+
+    with pytest.raises(ValidationError):
+        validate_payload(payload)

--- a/tests/test_ui_headless.py
+++ b/tests/test_ui_headless.py
@@ -1,0 +1,70 @@
+"""Headless mode tests for Qt applications."""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import dpkt
+
+from tspi_kit import TSPIProducer
+from tspi_kit.ui import HeadlessPlayerRunner, UiConfig
+from tspi_kit.ui.player import connect_in_memory
+from tspi_kit.ui.pcap_player import build_headless_player_from_pcap
+from tspi_kit.ui.generator import build_headless_generator
+
+
+def _geocentric_datagram(sensor_id: int, time_ticks: int) -> bytes:
+    header = struct.pack(
+        ">BBHHIBH",
+        0xC1,
+        4,
+        sensor_id,
+        120,
+        time_ticks,
+        0xFF,
+        0x01,
+    )
+    payload = struct.pack(
+        ">iii hhh hhh".replace(" ", ""),
+        1000,
+        2000,
+        3000,
+        100,
+        50,
+        20,
+        10,
+        5,
+        2,
+    )
+    return header + payload
+
+
+def test_headless_player_emits_metrics(capsys):
+    stream, receiver = connect_in_memory()
+    producer = TSPIProducer(stream)
+    for index in range(5):
+        producer.ingest(_geocentric_datagram(500 + index, 10_000 + index * 100), recv_time=1_700_000_000.0 + index)
+    runner = HeadlessPlayerRunner(
+        receiver,
+        ui_config=UiConfig(metrics_interval=0.0),
+        duration=0.1,
+        stdout_json=True,
+    )
+    runner.run()
+    out = capsys.readouterr().out
+    assert "frames" in out
+
+
+def test_pcap_headless_pipeline(tmp_path: Path):
+    datagram = _geocentric_datagram(600, 11_000)
+    pcap_path = tmp_path / "capture.pcap"
+    with pcap_path.open("wb") as handle:
+        writer = dpkt.pcap.Writer(handle, linktype=147)
+        writer.writepkt(datagram, ts=0.0)
+    runner = build_headless_player_from_pcap(pcap_path, rate=2.0)
+    runner.run()
+
+
+def test_generator_headless_pipeline():
+    runner = build_headless_generator(count=3, rate=5.0, duration=0.2)
+    runner.run()

--- a/tests/test_ui_player.py
+++ b/tests/test_ui_player.py
@@ -1,0 +1,91 @@
+"""UI tests for the JetStream player."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import struct
+
+import pytest
+from PyQt5 import QtCore
+
+from tspi_kit import InMemoryJetStream, TSPIProducer
+from tspi_kit.receiver import TSPIReceiver
+from tspi_kit.ui import JetStreamPlayerWindow
+
+
+@pytest.fixture
+def populated_player(qtbot):
+    stream = InMemoryJetStream()
+    producer = TSPIProducer(stream)
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    payloads = []
+    header_fmt = ">BBHHIBH"
+    payload_fmt = ">iii hhh hhh".replace(" ", "")
+    for index in range(5):
+        header = struct.pack(
+            header_fmt,
+            0xC1,
+            4,
+            100 + index,
+            200,
+            10_000 + index * 500,
+            0xFF,
+            0x01,
+        )
+        payload = struct.pack(
+            payload_fmt,
+            int(100.0 * 1),
+            int(200.0 * 1),
+            int(300.0 * 1),
+            int(10.0 * 100),
+            int(5.0 * 100),
+            int(2.0 * 100),
+            int(0.5 * 100),
+            int(0.25 * 100),
+            int(0.1 * 100),
+        )
+        datagram = header + payload
+        recv_time = base.timestamp() + index * 0.1
+        payloads.append(producer.ingest(datagram, recv_time=recv_time))
+    consumer = stream.create_consumer("tspi.>")
+    receiver = TSPIReceiver(consumer)
+    window = JetStreamPlayerWindow(receiver)
+    qtbot.addWidget(window)
+    window.state.preload()
+    return window, payloads
+
+
+def test_player_controls_toggle(populated_player, qtbot):
+    window, payloads = populated_player
+    assert not window.state.playing
+    qtbot.mouseClick(window.play_button, QtCore.Qt.LeftButton)
+    assert window.state.playing
+    window.step_once()
+    qtbot.mouseClick(window.play_button, QtCore.Qt.LeftButton)
+    assert not window.state.playing
+
+
+def test_seek_and_rate(populated_player, qtbot):
+    window, payloads = populated_player
+    qtbot.mouseClick(window.play_button, QtCore.Qt.LeftButton)
+    window.step_once()
+    buffer_before = window.state.buffer_size()
+    last_iso = payloads[-1]["recv_iso"]
+    window.seek_input.setText(last_iso)
+    qtbot.mouseClick(window.seek_button, QtCore.Qt.LeftButton)
+    assert window.state.buffer_size() <= buffer_before
+    window.rate_spin.setValue(2.0)
+    assert window.state.rate == pytest.approx(2.0)
+
+
+def test_map_smoothing(populated_player, qtbot):
+    window, payloads = populated_player
+    qtbot.mouseClick(window.play_button, QtCore.Qt.LeftButton)
+    first_state = window.map_widget.state
+    window.step_once()
+    second_state = window.map_widget.state
+    assert second_state.center != first_state.center
+    window.step_once()
+    third_state = window.map_widget.state
+    delta_first = abs(second_state.center[0] - first_state.center[0])
+    delta_second = abs(third_state.center[0] - second_state.center[0])
+    assert delta_second < delta_first

--- a/tspi_generator_qt.py
+++ b/tspi_generator_qt.py
@@ -1,0 +1,50 @@
+"""Entry point for the TSPI flight generator application."""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from PyQt5 import QtWidgets
+
+from tspi_kit.generator import FlightConfig, TSPIFlightGenerator
+from tspi_kit.producer import TSPIProducer
+from tspi_kit.ui import GeneratorController
+from tspi_kit.ui.player import connect_in_memory, ensure_offscreen
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TSPI Generator")
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--count", type=int, default=50)
+    parser.add_argument("--rate", type=float, default=50.0)
+    parser.add_argument("--duration", type=float, default=1.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ensure_offscreen(args.headless)
+    stream, _receiver = connect_in_memory()
+    producer = TSPIProducer(stream)
+    config = FlightConfig(count=args.count, rate_hz=args.rate)
+    generator = TSPIFlightGenerator(config)
+    controller = GeneratorController(generator, producer)
+
+    if args.headless:
+        controller.run(args.duration)
+        return 0
+
+    app = QtWidgets.QApplication(sys.argv)
+    window = QtWidgets.QWidget()
+    window.setWindowTitle("TSPI Flight Generator")
+    layout = QtWidgets.QVBoxLayout(window)
+    label = QtWidgets.QLabel("Generator Ready", window)
+    layout.addWidget(label)
+    window.show()
+    controller.metrics_updated.connect(lambda payload: label.setText(payload))
+    controller.run(args.duration)
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tspi_kit/__init__.py
+++ b/tspi_kit/__init__.py
@@ -1,0 +1,45 @@
+"""Toolkit primitives for Low-latency Stream Kit."""
+
+from .datagrams import ParsedTSPI, parse_tspi_datagram
+from .schema import load_schema, validate_payload
+from .jetstream import build_subject, message_headers
+from .jetstream_sim import InMemoryConsumer, InMemoryJetStream, InMemoryJetStreamCluster
+from .producer import TSPIProducer
+from .receiver import TSPIReceiver
+from .pcap import PCAPReplayer
+from .generator import FlightConfig, TSPIFlightGenerator
+from .ui import (
+    GeneratorController,
+    HeadlessPlayerRunner,
+    JetStreamPlayerWindow,
+    MapPreviewWidget,
+    MapSmoother,
+    PCAPPlayerController,
+    PlayerState,
+    UiConfig,
+)
+
+__all__ = [
+    "ParsedTSPI",
+    "parse_tspi_datagram",
+    "load_schema",
+    "validate_payload",
+    "build_subject",
+    "message_headers",
+    "InMemoryJetStream",
+    "InMemoryJetStreamCluster",
+    "InMemoryConsumer",
+    "TSPIProducer",
+    "TSPIReceiver",
+    "PCAPReplayer",
+    "FlightConfig",
+    "TSPIFlightGenerator",
+    "UiConfig",
+    "MapSmoother",
+    "MapPreviewWidget",
+    "JetStreamPlayerWindow",
+    "HeadlessPlayerRunner",
+    "PlayerState",
+    "PCAPPlayerController",
+    "GeneratorController",
+]

--- a/tspi_kit/datagrams.py
+++ b/tspi_kit/datagrams.py
@@ -1,0 +1,196 @@
+"""Binary datagram parsing utilities for BAPS TSPI telemetry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Literal
+import struct
+
+_DATAGRAM_LENGTH = 37
+_HEADER_FORMAT = ">BBHHIBH"
+_HEADER_SIZE = struct.calcsize(_HEADER_FORMAT)
+_PAYLOAD_SIZE = _DATAGRAM_LENGTH - _HEADER_SIZE
+
+_GEOCENTRIC_FORMAT = ">iii hhh hhh".replace(" ", "")
+_SPHERICAL_FORMAT = ">iII hhh hhh".replace(" ", "")
+
+
+class MessageType(Enum):
+    """Enumeration of supported TSPI datagram types."""
+
+    GEOCENTRIC = 0xC1
+    SPHERICAL = 0xC2
+
+    @classmethod
+    def from_byte(cls, value: int) -> "MessageType":
+        try:
+            return cls(value)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported message type byte: 0x{value:02x}") from exc
+
+
+@dataclass(frozen=True)
+class ParsedTSPI:
+    """Canonical representation of a TSPI datagram."""
+
+    type: Literal["geocentric", "spherical"]
+    sensor_id: int
+    day: int
+    time_s: float
+    time_ticks: int
+    status: int
+    status_flags: Dict[str, bool]
+    payload: Dict[str, float]
+    version: int = 4
+
+    def deduplication_id(self) -> str:
+        """Return a JetStream de-duplication identifier."""
+
+        return f"{self.sensor_id}:{self.day}:{self.time_ticks}"
+
+
+def _unpack_header(datagram: bytes) -> tuple[MessageType, int, int, int, int, int, int]:
+    if len(datagram) != _DATAGRAM_LENGTH:
+        raise ValueError(
+            f"TSPI datagram must be exactly {_DATAGRAM_LENGTH} bytes; received {len(datagram)}"
+        )
+
+    (
+        message_type_byte,
+        version,
+        sensor_id,
+        day,
+        time_ticks,
+        status,
+        status_flags,
+    ) = struct.unpack(_HEADER_FORMAT, datagram[:_HEADER_SIZE])
+
+    message_type = MessageType.from_byte(message_type_byte)
+    if version != 4:
+        raise ValueError(f"Unsupported datagram version: {version}")
+
+    return message_type, version, sensor_id, day, time_ticks, status, status_flags
+
+
+def _status_bits(status: int, status_flags: int) -> Dict[str, bool]:
+    combined = status | (status_flags << 8)
+    labels = [
+        "position_x_valid",
+        "position_y_valid",
+        "position_z_valid",
+        "velocity_x_valid",
+        "velocity_y_valid",
+        "velocity_z_valid",
+        "acceleration_x_valid",
+        "acceleration_y_valid",
+        "acceleration_z_valid",
+    ]
+    return {label: bool(combined & (1 << index)) for index, label in enumerate(labels)}
+
+
+def _parse_geocentric(payload: bytes) -> Dict[str, float]:
+    if len(payload) != _PAYLOAD_SIZE:
+        raise ValueError("Invalid geocentric payload length")
+
+    (
+        x_raw,
+        y_raw,
+        z_raw,
+        vx_raw,
+        vy_raw,
+        vz_raw,
+        ax_raw,
+        ay_raw,
+        az_raw,
+    ) = struct.unpack(_GEOCENTRIC_FORMAT, payload)
+
+    scale = 100.0
+    return {
+        "x_m": x_raw / scale,
+        "y_m": y_raw / scale,
+        "z_m": z_raw / scale,
+        "vx_mps": vx_raw / scale,
+        "vy_mps": vy_raw / scale,
+        "vz_mps": vz_raw / scale,
+        "ax_mps2": ax_raw / scale,
+        "ay_mps2": ay_raw / scale,
+        "az_mps2": az_raw / scale,
+    }
+
+
+def _parse_spherical(payload: bytes) -> Dict[str, float]:
+    if len(payload) != _PAYLOAD_SIZE:
+        raise ValueError("Invalid spherical payload length")
+
+    (
+        range_raw,
+        azimuth_raw,
+        elevation_raw,
+        az_rate_raw,
+        el_rate_raw,
+        range_rate_raw,
+        az_accel_raw,
+        el_accel_raw,
+        range_accel_raw,
+    ) = struct.unpack(_SPHERICAL_FORMAT, payload)
+
+    return {
+        "range_m": range_raw / 100.0,
+        "azimuth_deg": azimuth_raw / 1_000_000.0,
+        "elevation_deg": elevation_raw / 1_000_000.0,
+        "azimuth_rate_dps": az_rate_raw / 100.0,
+        "elevation_rate_dps": el_rate_raw / 100.0,
+        "range_rate_mps": range_rate_raw / 100.0,
+        "azimuth_accel_dps2": az_accel_raw / 100.0,
+        "elevation_accel_dps2": el_accel_raw / 100.0,
+        "range_accel_mps2": range_accel_raw / 100.0,
+    }
+
+
+def parse_tspi_datagram(datagram: bytes) -> ParsedTSPI:
+    """Parse a binary TSPI datagram into a :class:`ParsedTSPI` instance."""
+
+    (
+        message_type,
+        version,
+        sensor_id,
+        day,
+        time_ticks,
+        status,
+        status_flags,
+    ) = _unpack_header(datagram)
+
+    payload = datagram[_HEADER_SIZE:]
+    time_s = time_ticks / 10_000.0
+    status_mapping = _status_bits(status, status_flags)
+
+    if message_type is MessageType.GEOCENTRIC:
+        parsed_payload = _parse_geocentric(payload)
+        return ParsedTSPI(
+            type="geocentric",
+            sensor_id=sensor_id,
+            day=day,
+            time_s=time_s,
+            time_ticks=time_ticks,
+            status=status,
+            status_flags=status_mapping,
+            payload=parsed_payload,
+            version=version,
+        )
+
+    if message_type is MessageType.SPHERICAL:
+        parsed_payload = _parse_spherical(payload)
+        return ParsedTSPI(
+            type="spherical",
+            sensor_id=sensor_id,
+            day=day,
+            time_s=time_s,
+            time_ticks=time_ticks,
+            status=status,
+            status_flags=status_mapping,
+            payload=parsed_payload,
+            version=version,
+        )
+
+    # Should not reach here because unsupported types are handled earlier.
+    raise AssertionError("Unhandled message type")

--- a/tspi_kit/generator.py
+++ b/tspi_kit/generator.py
@@ -1,0 +1,96 @@
+"""Synthetic TSPI generator utilities for integration testing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import cos, sin, tau
+from typing import Iterable, List
+
+
+@dataclass
+class FlightConfig:
+    count: int = 50
+    rate_hz: float = 50.0
+    speed_min_mps: float = 50.0
+    speed_max_mps: float = 200.0
+    day: int = 120
+
+
+class TSPIFlightGenerator:
+    """Generate deterministic TSPI geocentric datagrams."""
+
+    def __init__(self, config: FlightConfig | None = None) -> None:
+        self._config = config or FlightConfig()
+        self._dt = 1.0 / self._config.rate_hz
+        self._frame_index = 0
+
+    def _sensor_id(self, index: int) -> int:
+        return 10_000 + index
+
+    def _header(self, sensor_id: int, time_ticks: int, status: int = 0xFF, flags: int = 0x01) -> bytes:
+        import struct
+
+        return struct.pack(
+            ">BBHHIBH",
+            0xC1,
+            4,
+            sensor_id,
+            self._config.day,
+            time_ticks,
+            status,
+            flags,
+        )
+
+    def _payload(self, angle: float, speed: float) -> bytes:
+        import struct
+
+        vx = speed * cos(angle)
+        vy = speed * sin(angle)
+        vz = 5.0
+        ax = 0.1 * cos(angle)
+        ay = 0.1 * sin(angle)
+        az = 0.0
+        x = vx * 10
+        y = vy * 10
+        z = 1000.0
+
+        return struct.pack(
+            ">iii hhh hhh".replace(" ", ""),
+            int(x * 100),
+            int(y * 100),
+            int(z * 100),
+            int(vx * 100),
+            int(vy * 100),
+            int(vz * 100),
+            int(ax * 100),
+            int(ay * 100),
+            int(az * 100),
+        )
+
+    def generate(self, frames: int) -> Iterable[tuple[bytes, float]]:
+        for _ in range(frames):
+            time_seconds = self._frame_index * self._dt
+            time_ticks = int(time_seconds * 10_000)
+            for aircraft in range(self._config.count):
+                angle = (aircraft / self._config.count) * tau
+                speed = self._config.speed_min_mps + (
+                    (self._config.speed_max_mps - self._config.speed_min_mps)
+                    * (aircraft / max(self._config.count - 1, 1))
+                )
+                payload = self._payload(angle + self._frame_index * 0.01, speed)
+                header = self._header(self._sensor_id(aircraft), time_ticks)
+                yield header + payload, time_seconds
+            self._frame_index += 1
+
+    def stream_to_producer(
+        self,
+        producer,
+        duration_seconds: float,
+        *,
+        base_epoch: float = 1_700_000_000.0,
+    ) -> List[dict]:
+        frames = int(duration_seconds * self._config.rate_hz)
+        results: List[dict] = []
+        for datagram, time_seconds in self.generate(frames):
+            result = producer.ingest(datagram, recv_time=base_epoch + time_seconds)
+            results.append(result)
+        return results

--- a/tspi_kit/jetstream.py
+++ b/tspi_kit/jetstream.py
@@ -1,0 +1,21 @@
+"""JetStream helpers used by the toolkit."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .datagrams import ParsedTSPI
+
+_STREAM_PREFIX = "tspi"
+
+
+def build_subject(message: ParsedTSPI, stream_prefix: str | None = None) -> str:
+    """Return the JetStream subject for the parsed datagram."""
+
+    prefix = stream_prefix or _STREAM_PREFIX
+    return f"{prefix}.{message.type}.{message.sensor_id}"
+
+
+def message_headers(message: ParsedTSPI) -> Dict[str, str]:
+    """Return JetStream headers for deduplication."""
+
+    return {"Nats-Msg-Id": message.deduplication_id()}

--- a/tspi_kit/jetstream_sim.py
+++ b/tspi_kit/jetstream_sim.py
@@ -1,0 +1,144 @@
+"""In-memory JetStream simulation utilities for integration tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass
+class JetStreamMessage:
+    """Container representing a message stored in the in-memory JetStream."""
+
+    subject: str
+    data: bytes
+    headers: Dict[str, str]
+    timestamp: float
+
+
+def _match_token(subject_token: str, pattern_token: str) -> bool:
+    if pattern_token == ">":
+        return True
+    if pattern_token == "*":
+        return True
+    return subject_token == pattern_token
+
+
+def _match_subject(subject: str, pattern: str) -> bool:
+    if pattern == ">":
+        return True
+
+    subject_tokens = subject.split(".")
+    pattern_tokens = pattern.split(".")
+
+    for index, token in enumerate(pattern_tokens):
+        if token == ">":
+            return True
+        if index >= len(subject_tokens):
+            return False
+        if not _match_token(subject_tokens[index], token):
+            return False
+
+    return len(subject_tokens) == len(pattern_tokens)
+
+
+class InMemoryConsumer:
+    """Simple pull consumer used for integration tests."""
+
+    def __init__(self, stream: "InMemoryJetStream", subject_filter: str):
+        self._stream = stream
+        self._subject_filter = subject_filter
+        self._cursor = 0
+        self._delivered = 0
+
+    def pull(self, batch: int) -> List[JetStreamMessage]:
+        messages: List[JetStreamMessage] = []
+
+        while len(messages) < batch and self._cursor < len(self._stream._messages):
+            message = self._stream._messages[self._cursor]
+            self._cursor += 1
+            if _match_subject(message.subject, self._subject_filter):
+                messages.append(message)
+
+        self._delivered += len(messages)
+        return messages
+
+    def pending(self) -> int:
+        matched = [
+            message
+            for message in self._stream._messages
+            if _match_subject(message.subject, self._subject_filter)
+        ]
+        return max(len(matched) - self._delivered, 0)
+
+
+class InMemoryJetStream:
+    """Minimal in-memory JetStream simulation supporting deduplication."""
+
+    def __init__(self) -> None:
+        self._messages: List[JetStreamMessage] = []
+        self._deduplication: Dict[str, JetStreamMessage] = {}
+
+    def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        timestamp: Optional[float] = None,
+    ) -> bool:
+        headers = headers or {}
+        timestamp = timestamp if timestamp is not None else 0.0
+        message_id = headers.get("Nats-Msg-Id")
+        if message_id is not None and message_id in self._deduplication:
+            return False
+
+        message = JetStreamMessage(subject, payload, headers, timestamp)
+        self._messages.append(message)
+        if message_id is not None:
+            self._deduplication[message_id] = message
+        return True
+
+    def create_consumer(self, subject_filter: str) -> InMemoryConsumer:
+        return InMemoryConsumer(self, subject_filter)
+
+
+class InMemoryJetStreamCluster(InMemoryJetStream):
+    """In-memory JetStream cluster with simple leader failover semantics."""
+
+    def __init__(self, replicas: int = 3) -> None:
+        super().__init__()
+        if replicas < 1:
+            raise ValueError("Cluster must contain at least one replica")
+        self._replicas = replicas
+        self._leader_index = 0
+        self._alive = [True] * replicas
+
+    @property
+    def leader_index(self) -> int:
+        return self._leader_index
+
+    def kill_leader(self) -> None:
+        self._alive[self._leader_index] = False
+        self._leader_index = self._next_leader()
+
+    def revive_all(self) -> None:
+        self._alive = [True] * self._replicas
+        self._leader_index = 0
+
+    def _next_leader(self) -> int:
+        for index, alive in enumerate(self._alive):
+            if alive:
+                return index
+        raise RuntimeError("No replicas available for leadership")
+
+    def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        timestamp: Optional[float] = None,
+    ) -> bool:
+        if not self._alive[self._leader_index]:
+            self._leader_index = self._next_leader()
+        return super().publish(subject, payload, headers=headers, timestamp=timestamp)

--- a/tspi_kit/pcap.py
+++ b/tspi_kit/pcap.py
@@ -1,0 +1,51 @@
+"""Utilities for replaying TSPI datagrams from PCAP files."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import dpkt
+
+
+@dataclass
+class PCAPPacket:
+    timestamp: float
+    payload: bytes
+
+
+class PCAPReplayer:
+    """Replay TSPI datagrams from a pcap/pcapng capture."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    def _iter_packets(self) -> Iterable[PCAPPacket]:
+        with self._path.open("rb") as handle:
+            reader = dpkt.pcap.Reader(handle)
+            for timestamp, payload in reader:
+                if len(payload) != 37:
+                    continue
+                yield PCAPPacket(timestamp=timestamp, payload=payload)
+
+    def replay(
+        self,
+        producer,
+        *,
+        rate: float = 1.0,
+        base_epoch: float | None = None,
+    ) -> List[dict]:
+        packets = list(self._iter_packets())
+        if not packets:
+            return []
+
+        first_timestamp = packets[0].timestamp
+        base_epoch = base_epoch if base_epoch is not None else first_timestamp
+
+        results: List[dict] = []
+        for packet in packets:
+            delta = packet.timestamp - first_timestamp
+            recv_time = base_epoch + delta / max(rate, 1e-9)
+            result = producer.ingest(packet.payload, recv_time=recv_time)
+            results.append(result)
+        return results

--- a/tspi_kit/producer.py
+++ b/tspi_kit/producer.py
@@ -1,0 +1,48 @@
+"""Headless TSPI producer that publishes to an in-memory JetStream."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+import time
+
+import cbor2
+
+from .datagrams import ParsedTSPI, parse_tspi_datagram
+from .jetstream import build_subject, message_headers
+
+
+class TSPIProducer:
+    """Parse raw TSPI datagrams and publish CBOR payloads."""
+
+    def __init__(self, publisher, *, stream_prefix: str = "tspi") -> None:
+        self._publisher = publisher
+        self._stream_prefix = stream_prefix
+
+    def _encode_payload(self, parsed: ParsedTSPI, recv_time: float) -> Dict[str, object]:
+        recv_epoch_ms = int(round(recv_time * 1000))
+        recv_iso = datetime.fromtimestamp(recv_time, tz=timezone.utc).isoformat()
+        payload: Dict[str, object] = {
+            "type": parsed.type,
+            "sensor_id": parsed.sensor_id,
+            "day": parsed.day,
+            "time_s": parsed.time_s,
+            "status": parsed.status,
+            "status_flags": parsed.status_flags,
+            "recv_epoch_ms": recv_epoch_ms,
+            "recv_iso": recv_iso,
+            "payload": parsed.payload,
+        }
+        return payload
+
+    def ingest(self, datagram: bytes, *, recv_time: Optional[float] = None) -> Dict[str, object]:
+        parsed = parse_tspi_datagram(datagram)
+        recv_time = recv_time if recv_time is not None else time.time()
+        payload = self._encode_payload(parsed, recv_time)
+
+        subject = build_subject(parsed, stream_prefix=self._stream_prefix)
+        headers = message_headers(parsed)
+
+        encoded = cbor2.dumps(payload)
+        self._publisher.publish(subject, encoded, headers=headers, timestamp=recv_time)
+        return payload

--- a/tspi_kit/receiver.py
+++ b/tspi_kit/receiver.py
@@ -1,0 +1,35 @@
+"""Durable JetStream consumer utilities for integration tests."""
+from __future__ import annotations
+
+from typing import List
+
+import cbor2
+
+from .schema import validate_payload
+
+
+class TSPIReceiver:
+    """Pull messages from JetStream and decode CBOR payloads."""
+
+    def __init__(self, consumer, *, validate: bool = True) -> None:
+        self._consumer = consumer
+        self._validate = validate
+
+    def fetch(self, batch: int = 1) -> List[dict]:
+        messages = self._consumer.pull(batch)
+        decoded: List[dict] = []
+        for message in messages:
+            payload = cbor2.loads(message.data)
+            if self._validate:
+                validate_payload(payload)
+            decoded.append(payload)
+        return decoded
+
+    def fetch_all(self, batch_size: int = 50) -> List[dict]:
+        results: List[dict] = []
+        while True:
+            batch = self.fetch(batch_size)
+            if not batch:
+                break
+            results.extend(batch)
+        return results

--- a/tspi_kit/schema.py
+++ b/tspi_kit/schema.py
@@ -1,0 +1,30 @@
+"""Schema loading and validation helpers for TSPI payloads."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+_SCHEMA_PATH = Path(__file__).with_name("tspi.schema.json")
+
+
+@lru_cache(maxsize=1)
+def load_schema() -> Mapping[str, Any]:
+    """Load and cache the TSPI JSON schema as a mapping."""
+
+    return json.loads(_SCHEMA_PATH.read_text("utf-8"))
+
+
+@lru_cache(maxsize=1)
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(load_schema())
+
+
+def validate_payload(payload: Mapping[str, Any]) -> None:
+    """Validate ``payload`` against the TSPI schema."""
+
+    validator = _validator()
+    validator.validate(payload)

--- a/tspi_kit/tspi.schema.json
+++ b/tspi_kit/tspi.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/tspi.schema.json",
+  "title": "BAPS TSPI Payload",
+  "type": "object",
+  "required": [
+    "type",
+    "sensor_id",
+    "day",
+    "time_s",
+    "status",
+    "status_flags",
+    "payload",
+    "recv_epoch_ms",
+    "recv_iso"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["geocentric", "spherical"]
+    },
+    "sensor_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "day": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 366
+    },
+    "time_s": {
+      "type": "number",
+      "minimum": 0
+    },
+    "status": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "status_flags": {
+      "$ref": "#/definitions/statusFlags"
+    },
+    "recv_epoch_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "recv_iso": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {"const": "geocentric"}
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {"$ref": "#/definitions/geocentricPayload"}
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {"const": "spherical"}
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {"$ref": "#/definitions/sphericalPayload"}
+        }
+      }
+    }
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "statusFlags": {
+      "type": "object",
+      "required": [
+        "position_x_valid",
+        "position_y_valid",
+        "position_z_valid",
+        "velocity_x_valid",
+        "velocity_y_valid",
+        "velocity_z_valid",
+        "acceleration_x_valid",
+        "acceleration_y_valid",
+        "acceleration_z_valid"
+      ],
+      "properties": {
+        "position_x_valid": {"type": "boolean"},
+        "position_y_valid": {"type": "boolean"},
+        "position_z_valid": {"type": "boolean"},
+        "velocity_x_valid": {"type": "boolean"},
+        "velocity_y_valid": {"type": "boolean"},
+        "velocity_z_valid": {"type": "boolean"},
+        "acceleration_x_valid": {"type": "boolean"},
+        "acceleration_y_valid": {"type": "boolean"},
+        "acceleration_z_valid": {"type": "boolean"}
+      },
+      "additionalProperties": false
+    },
+    "geocentricPayload": {
+      "type": "object",
+      "required": [
+        "x_m",
+        "y_m",
+        "z_m",
+        "vx_mps",
+        "vy_mps",
+        "vz_mps",
+        "ax_mps2",
+        "ay_mps2",
+        "az_mps2"
+      ],
+      "properties": {
+        "x_m": {"type": "number"},
+        "y_m": {"type": "number"},
+        "z_m": {"type": "number"},
+        "vx_mps": {"type": "number"},
+        "vy_mps": {"type": "number"},
+        "vz_mps": {"type": "number"},
+        "ax_mps2": {"type": "number"},
+        "ay_mps2": {"type": "number"},
+        "az_mps2": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "sphericalPayload": {
+      "type": "object",
+      "required": [
+        "range_m",
+        "azimuth_deg",
+        "elevation_deg",
+        "azimuth_rate_dps",
+        "elevation_rate_dps",
+        "range_rate_mps",
+        "azimuth_accel_dps2",
+        "elevation_accel_dps2",
+        "range_accel_mps2"
+      ],
+      "properties": {
+        "range_m": {"type": "number"},
+        "azimuth_deg": {"type": "number"},
+        "elevation_deg": {"type": "number"},
+        "azimuth_rate_dps": {"type": "number"},
+        "elevation_rate_dps": {"type": "number"},
+        "range_rate_mps": {"type": "number"},
+        "azimuth_accel_dps2": {"type": "number"},
+        "elevation_accel_dps2": {"type": "number"},
+        "range_accel_mps2": {"type": "number"}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tspi_kit/ui/__init__.py
+++ b/tspi_kit/ui/__init__.py
@@ -1,0 +1,18 @@
+"""Qt5 UI helpers for the TSPI tool suite."""
+
+from .config import UiConfig
+from .map import MapSmoother, MapPreviewWidget
+from .player import JetStreamPlayerWindow, HeadlessPlayerRunner, PlayerState
+from .pcap_player import PCAPPlayerController
+from .generator import GeneratorController
+
+__all__ = [
+    "UiConfig",
+    "MapSmoother",
+    "MapPreviewWidget",
+    "JetStreamPlayerWindow",
+    "HeadlessPlayerRunner",
+    "PlayerState",
+    "PCAPPlayerController",
+    "GeneratorController",
+]

--- a/tspi_kit/ui/config.py
+++ b/tspi_kit/ui/config.py
@@ -1,0 +1,18 @@
+"""Shared configuration values for Qt applications."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class UiConfig:
+    """Runtime configuration for UI and headless runners."""
+
+    smooth_center: float = 0.85
+    smooth_zoom: float = 0.85
+    window_sec: int = 10
+    metrics_interval: float = 1.0
+    rate_min: float = 0.01
+    rate_max: float = 4.0
+    default_rate: float = 1.0
+    default_clock: str = "receive"

--- a/tspi_kit/ui/generator.py
+++ b/tspi_kit/ui/generator.py
@@ -1,0 +1,70 @@
+"""Qt controller for the TSPI flight generator."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from PyQt5 import QtCore
+
+from ..generator import FlightConfig, TSPIFlightGenerator
+from ..producer import TSPIProducer
+from .config import UiConfig
+from .player import HeadlessPlayerRunner, connect_in_memory
+
+
+@dataclass(slots=True)
+class GeneratorMetrics:
+    frames_generated: int = 0
+    aircraft: int = 0
+    rate: float = 0.0
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "frames_generated": self.frames_generated,
+            "aircraft": self.aircraft,
+            "rate": self.rate,
+        })
+
+
+class GeneratorController(QtCore.QObject):
+    """Drive the TSPI flight generator and publish to JetStream."""
+
+    metrics_updated = QtCore.pyqtSignal(str)
+
+    def __init__(
+        self,
+        generator: TSPIFlightGenerator,
+        producer: TSPIProducer,
+        *,
+        ui_config: Optional[UiConfig] = None,
+    ) -> None:
+        super().__init__()
+        self._generator = generator
+        self._producer = producer
+        self._config = ui_config or UiConfig()
+        self._metrics = GeneratorMetrics(
+            aircraft=generator._config.count,
+            rate=generator._config.rate_hz,
+        )
+
+    def run(self, duration: float) -> None:
+        frames = int(duration * self._generator._config.rate_hz)
+        messages = self._generator.stream_to_producer(self._producer, duration_seconds=duration)
+        self._metrics.frames_generated += len(messages)
+        self.metrics_updated.emit(self._metrics.to_json())
+
+
+def build_headless_generator(
+    *,
+    count: int = 5,
+    rate: float = 10.0,
+    duration: float = 1.0,
+) -> HeadlessPlayerRunner:
+    stream, receiver = connect_in_memory()
+    producer = TSPIProducer(stream)
+    config = FlightConfig(count=count, rate_hz=rate)
+    generator = TSPIFlightGenerator(config)
+    controller = GeneratorController(generator, producer)
+    controller.run(duration)
+    return HeadlessPlayerRunner(receiver)

--- a/tspi_kit/ui/map.py
+++ b/tspi_kit/ui/map.py
@@ -1,0 +1,69 @@
+"""Map preview helpers with smoothing support."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from PyQt5 import QtCore, QtWidgets
+
+
+@dataclass(slots=True)
+class MapState:
+    center: Tuple[float, float] = (0.0, 0.0)
+    zoom: float = 1.0
+
+
+class MapSmoother:
+    """Apply exponential smoothing to map center/zoom updates."""
+
+    def __init__(self, *, smooth_center: float = 0.85, smooth_zoom: float = 0.85) -> None:
+        if not (0.0 <= smooth_center <= 1.0 and 0.0 <= smooth_zoom <= 1.0):
+            raise ValueError("Smoothing factors must be within [0, 1]")
+        self._smooth_center = smooth_center
+        self._smooth_zoom = smooth_zoom
+        self._state: Optional[MapState] = None
+
+    @property
+    def state(self) -> MapState:
+        if self._state is None:
+            self._state = MapState()
+        return self._state
+
+    def update(self, center: Tuple[float, float], zoom: float) -> MapState:
+        if self._state is None:
+            self._state = MapState()
+
+        cx = self._smooth_center * self._state.center[0] + (1 - self._smooth_center) * center[0]
+        cy = self._smooth_center * self._state.center[1] + (1 - self._smooth_center) * center[1]
+        z = self._smooth_zoom * self._state.zoom + (1 - self._smooth_zoom) * zoom
+        self._state = MapState(center=(cx, cy), zoom=z)
+        return self._state
+
+
+class MapPreviewWidget(QtWidgets.QWidget):
+    """Lightweight widget that stores smoothed map state for tests."""
+
+    state_changed = QtCore.pyqtSignal(MapState)
+
+    def __init__(self, smoother: MapSmoother, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._smoother = smoother
+        self._label = QtWidgets.QLabel("Map Preview", self)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self._label)
+        self._state = self._smoother.state
+        self._update_label()
+
+    @property
+    def state(self) -> MapState:
+        return self._state
+
+    def apply_position(self, center: Tuple[float, float], zoom: float) -> MapState:
+        self._state = self._smoother.update(center, zoom)
+        self._update_label()
+        self.state_changed.emit(self._state)
+        return self._state
+
+    def _update_label(self) -> None:
+        center_x, center_y = self._state.center
+        self._label.setText(f"Center: {center_x:.2f}, {center_y:.2f} | Zoom: {self._state.zoom:.2f}")

--- a/tspi_kit/ui/pcap_player.py
+++ b/tspi_kit/ui/pcap_player.py
@@ -1,0 +1,67 @@
+"""Qt controller for the PCAP player."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from PyQt5 import QtCore
+
+from ..pcap import PCAPReplayer
+from ..producer import TSPIProducer
+from .config import UiConfig
+from .player import HeadlessPlayerRunner, connect_in_memory
+
+
+@dataclass(slots=True)
+class PCAPMetrics:
+    frames_sent: int = 0
+    rate: float = 1.0
+    loop: bool = False
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "frames_sent": self.frames_sent,
+            "rate": self.rate,
+            "loop": self.loop,
+        })
+
+
+class PCAPPlayerController(QtCore.QObject):
+    """Headless-friendly PCAP replay controller."""
+
+    metrics_updated = QtCore.pyqtSignal(str)
+
+    def __init__(
+        self,
+        replayer: PCAPReplayer,
+        producer: TSPIProducer,
+        *,
+        rate: float = 1.0,
+        loop: bool = False,
+        ui_config: Optional[UiConfig] = None,
+    ) -> None:
+        super().__init__()
+        self._replayer = replayer
+        self._producer = producer
+        self._rate = rate
+        self._loop = loop
+        self._config = ui_config or UiConfig()
+        self._metrics = PCAPMetrics(rate=rate, loop=loop)
+
+    def replay(self) -> None:
+        packets = self._replayer.replay(self._producer, rate=self._rate, base_epoch=time.time())
+        self._metrics.frames_sent += len(packets)
+        self.metrics_updated.emit(self._metrics.to_json())
+        if self._loop and packets:
+            self.replay()
+
+
+def build_headless_player_from_pcap(path, *, rate: float = 1.0) -> HeadlessPlayerRunner:
+    stream, receiver = connect_in_memory()
+    producer = TSPIProducer(stream)
+    replayer = PCAPReplayer(path)
+    controller = PCAPPlayerController(replayer, producer, rate=rate)
+    controller.replay()
+    return HeadlessPlayerRunner(receiver)

--- a/tspi_kit/ui/player.py
+++ b/tspi_kit/ui/player.py
@@ -1,0 +1,296 @@
+"""Qt-based JetStream player implementation."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from PyQt5 import QtCore, QtWidgets
+
+from ..jetstream_sim import InMemoryJetStream
+from ..receiver import TSPIReceiver
+from ..schema import validate_payload
+from .config import UiConfig
+from .map import MapPreviewWidget, MapSmoother
+
+
+@dataclass(slots=True)
+class PlayerMetrics:
+    frames: int = 0
+    rate: float = 0.0
+    clock: str = "receive"
+    lag: int = 0
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "frames": self.frames,
+            "rate": self.rate,
+            "clock": self.clock,
+            "lag": self.lag,
+        })
+
+
+class PlayerState(QtCore.QObject):
+    """Controller shared between GUI and headless playback."""
+
+    metrics_updated = QtCore.pyqtSignal(PlayerMetrics)
+
+    def __init__(
+        self,
+        receiver: TSPIReceiver,
+        *,
+        ui_config: UiConfig,
+        map_widget: Optional[MapPreviewWidget] = None,
+    ) -> None:
+        super().__init__()
+        self._receiver = receiver
+        self._ui_config = ui_config
+        self._map_widget = map_widget
+        self._playing = False
+        self._buffer: List[dict] = []
+        self._metrics = PlayerMetrics(clock=ui_config.default_clock, rate=ui_config.default_rate)
+        self._last_metrics = time.monotonic()
+        self._timer = QtCore.QTimer()
+        self._timer.setInterval(50)
+        self._timer.timeout.connect(self._tick)
+        self._clock_source = ui_config.default_clock
+        self._rate = ui_config.default_rate
+
+    @property
+    def playing(self) -> bool:
+        return self._playing
+
+    @property
+    def clock_source(self) -> str:
+        return self._clock_source
+
+    @property
+    def rate(self) -> float:
+        return self._rate
+
+    def set_rate(self, value: float) -> None:
+        self._rate = max(self._ui_config.rate_min, min(self._ui_config.rate_max, value))
+        self._metrics.rate = self._rate
+
+    def set_clock_source(self, value: str) -> None:
+        self._clock_source = value
+        self._metrics.clock = value
+
+    def start(self) -> None:
+        if not self._playing:
+            self._playing = True
+            self._timer.start()
+
+    def pause(self) -> None:
+        if self._playing:
+            self._playing = False
+            self._timer.stop()
+
+    def seek(self, iso_timestamp: str) -> None:
+        try:
+            target = datetime.fromisoformat(iso_timestamp)
+        except ValueError:
+            return
+        target_epoch = target.timestamp()
+        self._buffer = [
+            message
+            for message in self._buffer
+            if message.get("recv_iso") and datetime.fromisoformat(message["recv_iso"]).timestamp() >= target_epoch
+        ]
+
+    def preload(self, batch: int = 50) -> None:
+        messages = self._receiver.fetch(batch=batch)
+        for message in messages:
+            validate_payload(message)
+        self._buffer.extend(messages)
+
+    def _tick(self) -> None:
+        if not self._playing:
+            return
+        if not self._buffer:
+            self.preload()
+            if not self._buffer:
+                self.pause()
+                return
+        message = self._buffer.pop(0)
+        self._metrics.frames += 1
+        if self._map_widget:
+            payload = message.get("payload", {})
+            center = (
+                float(payload.get("x_m", payload.get("range_m", 0.0))),
+                float(payload.get("y_m", payload.get("azimuth_deg", 0.0))),
+            )
+            zoom = 1.0 + abs(float(payload.get("vx_mps", payload.get("range_rate_mps", 0.0)))) * 0.01
+            self._map_widget.apply_position(center, zoom)
+
+        now = time.monotonic()
+        if now - self._last_metrics >= self._ui_config.metrics_interval:
+            self._last_metrics = now
+            if hasattr(self._receiver, "_consumer"):
+                pending = getattr(self._receiver._consumer, "pending", lambda: 0)()
+            else:
+                pending = 0
+            self._metrics.lag = pending
+            self.metrics_updated.emit(self._metrics)
+
+    def step_once(self) -> None:
+        self._tick()
+
+    def buffer_size(self) -> int:
+        return len(self._buffer)
+
+    def buffer_snapshot(self) -> List[dict]:
+        return list(self._buffer)
+
+
+class JetStreamPlayerWindow(QtWidgets.QMainWindow):
+    """Qt main window for the JetStream player."""
+
+    def __init__(
+        self,
+        receiver: TSPIReceiver,
+        *,
+        ui_config: Optional[UiConfig] = None,
+        parent: Optional[QtWidgets.QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("JetStream Player")
+        self._config = ui_config or UiConfig()
+        self._map = MapPreviewWidget(MapSmoother(
+            smooth_center=self._config.smooth_center,
+            smooth_zoom=self._config.smooth_zoom,
+        ))
+        self._state = PlayerState(receiver, ui_config=self._config, map_widget=self._map)
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        central = QtWidgets.QWidget(self)
+        layout = QtWidgets.QVBoxLayout(central)
+        self.setCentralWidget(central)
+
+        control_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(control_layout)
+
+        self.connect_button = QtWidgets.QPushButton("Connect", self)
+        control_layout.addWidget(self.connect_button)
+
+        self.play_button = QtWidgets.QPushButton("Play", self)
+        control_layout.addWidget(self.play_button)
+        self.play_button.clicked.connect(self._toggle_play)
+
+        self.seek_input = QtWidgets.QLineEdit(self)
+        self.seek_input.setPlaceholderText("ISO timestamp")
+        control_layout.addWidget(self.seek_input)
+
+        self.seek_button = QtWidgets.QPushButton("Seek", self)
+        control_layout.addWidget(self.seek_button)
+        self.seek_button.clicked.connect(self._on_seek)
+
+        self.rate_spin = QtWidgets.QDoubleSpinBox(self)
+        self.rate_spin.setRange(self._config.rate_min, self._config.rate_max)
+        self.rate_spin.setValue(self._config.default_rate)
+        control_layout.addWidget(self.rate_spin)
+        self.rate_spin.valueChanged.connect(self._state.set_rate)
+
+        self.clock_combo = QtWidgets.QComboBox(self)
+        self.clock_combo.addItems(["receive", "tspi"])
+        control_layout.addWidget(self.clock_combo)
+        self.clock_combo.currentTextChanged.connect(self._state.set_clock_source)
+
+        layout.addWidget(self._map)
+
+        self._metrics_label = QtWidgets.QLabel("Frames: 0", self)
+        layout.addWidget(self._metrics_label)
+
+        self._state.metrics_updated.connect(self._update_metrics)
+
+    def _toggle_play(self) -> None:
+        if self._state.playing:
+            self._state.pause()
+            self.play_button.setText("Play")
+        else:
+            self._state.start()
+            self.play_button.setText("Pause")
+
+    def _on_seek(self) -> None:
+        self._state.seek(self.seek_input.text())
+
+    def _update_metrics(self, metrics: PlayerMetrics) -> None:
+        self._metrics_label.setText(metrics.to_json())
+
+    def step_once(self) -> None:
+        self._state.step_once()
+
+    @property
+    def map_widget(self) -> MapPreviewWidget:
+        return self._map
+
+    @property
+    def state(self) -> PlayerState:
+        return self._state
+
+
+class HeadlessPlayerRunner:
+    """Headless playback runner emitting metrics as JSON."""
+
+    def __init__(
+        self,
+        receiver: TSPIReceiver,
+        *,
+        ui_config: Optional[UiConfig] = None,
+        stdout_json: bool = True,
+        duration: Optional[float] = None,
+        exit_on_idle: Optional[float] = None,
+        write_cbor_dir: Optional[Path] = None,
+    ) -> None:
+        self._config = ui_config or UiConfig()
+        self._state = PlayerState(receiver, ui_config=self._config)
+        self._stdout_json = stdout_json
+        self._duration = duration
+        self._exit_on_idle = exit_on_idle
+        self._write_cbor_dir = write_cbor_dir
+        self._start_time = time.monotonic()
+        self._last_activity = self._start_time
+        if write_cbor_dir:
+            write_cbor_dir.mkdir(parents=True, exist_ok=True)
+        self._state.metrics_updated.connect(self._on_metrics)
+
+    def run(self) -> None:
+        self._state.start()
+        while True:
+            self._state.step_once()
+            now = time.monotonic()
+            if self._duration is not None and now - self._start_time >= self._duration:
+                break
+            if self._exit_on_idle is not None and now - self._last_activity >= self._exit_on_idle:
+                break
+            if not self._state.playing:
+                if self._state.buffer_size() == 0:
+                    break
+                time.sleep(0.01)
+            else:
+                self._last_activity = now
+                time.sleep(max(0.001, 0.05 / self._state.rate))
+
+    def _on_metrics(self, metrics: PlayerMetrics) -> None:
+        if self._stdout_json:
+            print(metrics.to_json())
+        if self._write_cbor_dir:
+            path = self._write_cbor_dir / f"frame_{metrics.frames:06d}.cbor"
+            path.write_bytes(b"")
+
+
+def connect_in_memory() -> tuple[InMemoryJetStream, TSPIReceiver]:
+    stream = InMemoryJetStream()
+    consumer = stream.create_consumer("tspi.>")
+    receiver = TSPIReceiver(consumer)
+    return stream, receiver
+
+
+def ensure_offscreen(headless: bool) -> None:
+    if headless:
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")


### PR DESCRIPTION
## Summary
- implement Qt5 GUI/headless scaffolding for the JetStream player, PCAP player, and TSPI generator with smoothed map preview support
- expose the new UI controllers through the package API, adjust CI requirements, and configure tests to run Qt in offscreen mode
- add pytest-qt driven GUI exercises and headless pipeline tests to cover the spec’s interface and integration scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78064f77c83299c728406deda7fd9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce full TSPI toolkit (parsing, producer/receiver, PCAP replay, flight generator), Qt5 GUI/headless players, comprehensive tests, and CI.
> 
> - **Core toolkit**:
>   - Implement TSPI parsing (`tspi_kit/datagrams.py`), JSON Schema + validation (`tspi_kit/tspi.schema.json`, `tspi_kit/schema.py`).
>   - Add in-memory JetStream with consumer and cluster failover (`tspi_kit/jetstream_sim.py`) and helpers (`tspi_kit/jetstream.py`).
>   - Add producer/receiver for CBOR publishing/consuming (`tspi_kit/producer.py`, `tspi_kit/receiver.py`).
>   - PCAP replay and synthetic generator utilities (`tspi_kit/pcap.py`, `tspi_kit/generator.py`).
>   - Public API surface in `tspi_kit/__init__.py`.
> - **Qt5 UI**:
>   - Player window, headless runner, map preview+smoothing, shared config (`tspi_kit/ui/*`).
>   - PCAP and generator controllers (`tspi_kit/ui/pcap_player.py`, `tspi_kit/ui/generator.py`).
>   - CLI entrypoints: `player_qt.py`, `pcap_player_qt.py`, `tspi_generator_qt.py`.
> - **Tests**:
>   - Add datagram, schema, integration, headless, and GUI tests (`tests/*.py`), with Qt offscreen setup (`tests/conftest.py`).
> - **CI**:
>   - New GitHub Actions workflow to run pytest on Ubuntu/macOS (`.github/workflows/ci.yml`).
> - **Dependencies**:
>   - Add `PyQt5` and `pytest-qt` to `requirements.txt`.
> - **Docs**:
>   - Update `README.md` features and testing sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7caf1d5eaaac31613b80980269d8da7ceb745aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->