### PR TITLE
Fix stdout json argument bug

### DIFF
--- a/pcap_player_qt.py
+++ b/pcap_player_qt.py
@@ -20,7 +20,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--rate", type=float, default=1.0)
     parser.add_argument("--loop", action="store_true")
     parser.add_argument("--metrics-interval", type=float, default=1.0)
-    parser.add_argument("--stdout-json", action="store_true", default=True)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--stdout-json",
+        dest="stdout_json",
+        action="store_true",
+        default=True,
+        help="Enable JSON metrics on stdout (default)",
+    )
+    group.add_argument(
+        "--no-stdout-json",
+        dest="stdout_json",
+        action="store_false",
+        help="Disable JSON metrics on stdout",
+    )
     return parser.parse_args(argv)
 
 

--- a/player_qt.py
+++ b/player_qt.py
@@ -17,7 +17,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--metrics-interval", type=float, default=1.0)
     parser.add_argument("--duration", type=float)
     parser.add_argument("--exit-on-idle", type=float)
-    parser.add_argument("--stdout-json", action="store_true", default=True)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--stdout-json",
+        dest="stdout_json",
+        action="store_true",
+        default=True,
+        help="Enable JSON metrics on stdout (default)",
+    )
+    group.add_argument(
+        "--no-stdout-json",
+        dest="stdout_json",
+        action="store_false",
+        help="Disable JSON metrics on stdout",
+    )
     parser.add_argument("--write-cbor", type=Path)
     parser.add_argument("--rate", type=float, default=1.0)
     parser.add_argument("--room", type=str, default="default")


### PR DESCRIPTION
Add `--no-stdout-json` flag to allow disabling JSON output, fixing a bug where it was always enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-b79b1053-53fe-4d93-993d-4382ad5aba3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b79b1053-53fe-4d93-993d-4382ad5aba3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

