### PR TITLE
Add Debian 13 GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [debian-13, macos-14]
         python-version: ["3.11"]
 
     steps:

--- a/.github/workflows/player-receiver-integration.yml
+++ b/.github/workflows/player-receiver-integration.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   player-receiver:
     name: Player/Receiver JetStream Integration (Python 3.11)
-    runs-on: ubuntu-latest
+    runs-on: debian-13
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- update the CI matrix so Linux jobs run on the debian-13 runner
- switch the player/receiver integration workflow to debian-13

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c907ef1c8329b9c672dbee8eedb1