### PR TITLE
Add standalone UDP producer and async ingestion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ pip install -e .[ui]
 
 ## Components
 ### producer.py
-- UDP listener on port 30000 (configurable)
+- Standalone asyncio CLI that binds to UDP (default port 30000)
 - Parses BAPS TSPI v4 datagrams → Python dict → CBOR
 - Publishes to `tspi.geocentric.<sensor_id>` or `tspi.spherical.<sensor_id>`
 - Dedup headers: `Nats-Msg-Id = "<sensor>:<day>:<time_s>"`
-- Options: sensor filters, custom stream, multiple NATS servers
+- Options: sensor filters (`--sensor-id`), custom stream prefix, multiple NATS servers,
+  publish timeout, log level
 
 ### receiver.py
 - Durable consumer on `tspi.>`

--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -4,9 +4,7 @@
 This document captures the current discrepancies between the published specifications/README and the implementation that ships in this repository.
 
 ## Producer / Ingestion Pipeline
-- **README expectation:** `producer.py` is a standalone UDP listener that connects to a live NATS JetStream cluster (`python producer.py --nats-server ...`).【F:README.md†L34-L45】【F:README.md†L47-L53】
-- **Implementation reality:** The only producer is `tspi_kit.producer.TSPIProducer`, a helper that accepts already-received datagrams and publishes them via an injected publisher object; it never opens a UDP socket or a CLI entry point and is scoped to an in-memory JetStream helper.【F:tspi_kit/producer.py†L1-L48】 The repository root also has no `producer.py` script matching the advertised command.【83c4fc†L1-L4】
-- **Spec expectation:** The change specification reiterates that the Producer is a UDP ingest process that publishes exclusively to JetStream.【F:docs/player_receiver_jetstream.md†L5-L22】
+- ✅ `producer.py` now exists as a standalone asyncio CLI. It binds to UDP, parses TSPI datagrams with `TSPIProducer`, and publishes to JetStream using the official NATS client, matching both the README and change specification.【F:producer.py†L1-L109】【F:README.md†L6-L45】
 
 ## Receiver / Consumer
 - **README expectation:** `receiver.py` is a durable JetStream consumer CLI with toggles for JSON streaming (`--json-stream/--no-json-stream`).【F:README.md†L55-L59】

--- a/producer.py
+++ b/producer.py
@@ -1,0 +1,127 @@
+"""Standalone UDP → JetStream TSPI producer."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import signal
+import sys
+from typing import Iterable, Sequence
+
+from nats.aio.client import Client as NATS
+
+from tspi_kit.producer import TSPIProducer
+from tspi_kit.udp_ingest import AsyncJetStreamPublisher, UDPIngestProtocol
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="UDP TSPI producer for JetStream")
+    parser.add_argument(
+        "--udp-host",
+        default="0.0.0.0",
+        help="UDP host/interface to bind (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--udp-port",
+        type=int,
+        default=30000,
+        help="UDP port to listen on for TSPI datagrams (default: 30000)",
+    )
+    parser.add_argument(
+        "--nats-server",
+        action="append",
+        dest="nats_servers",
+        default=None,
+        help="NATS JetStream server URL. Specify multiple times for failover.",
+    )
+    parser.add_argument(
+        "--stream-prefix",
+        default="tspi",
+        help="Subject prefix used when publishing to JetStream (default: tspi)",
+    )
+    parser.add_argument(
+        "--sensor-id",
+        type=int,
+        action="append",
+        dest="sensor_ids",
+        default=None,
+        help="Only ingest datagrams from the specified sensor id. Repeatable.",
+    )
+    parser.add_argument(
+        "--publish-timeout",
+        type=float,
+        default=2.0,
+        help="Timeout (seconds) for JetStream publish operations.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Logging level for the producer (default: INFO)",
+    )
+    return parser
+
+
+async def _run_async(args: argparse.Namespace) -> int:
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    nats_servers: Sequence[str] = (
+        args.nats_servers if args.nats_servers is not None else ["nats://127.0.0.1:4222"]
+    )
+
+    logging.info("Connecting to NATS JetStream at %s", ", ".join(nats_servers))
+    nc = NATS()
+    await nc.connect(servers=list(nats_servers))
+    js = nc.jetstream()
+
+    publisher = AsyncJetStreamPublisher(js, publish_timeout=args.publish_timeout)
+    allowed_sensors: Iterable[int] | None = (
+        set(args.sensor_ids) if args.sensor_ids is not None else None
+    )
+    producer = TSPIProducer(
+        publisher,
+        stream_prefix=args.stream_prefix,
+        allowed_sensors=allowed_sensors,
+    )
+
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+
+    for sig in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None)):
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - Windows fallback
+            pass
+
+    transport, protocol = await loop.create_datagram_endpoint(
+        lambda: UDPIngestProtocol(producer, loop=loop),
+        local_addr=(args.udp_host, args.udp_port),
+    )
+
+    try:
+        await stop_event.wait()
+    finally:
+        transport.close()
+        await protocol.drain()
+        await nc.drain()
+        await nc.close()
+
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_run_async(args))
+    except KeyboardInterrupt:  # pragma: no cover - handled via signal but for safety
+        return 130
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/test_udp_ingest.py
+++ b/tests/test_udp_ingest.py
@@ -1,0 +1,120 @@
+"""Tests covering the standalone UDP producer helpers."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from tspi_kit import InMemoryJetStream
+from tspi_kit.producer import TSPIProducer
+from tspi_kit.udp_ingest import AsyncJetStreamPublisher, UDPIngestProtocol
+
+
+def _geocentric_datagram(sensor_id: int = 101, day: int = 200, time_ticks: int = 10_000) -> bytes:
+    import struct
+
+    header = struct.pack(
+        ">BBHHIBH",
+        0xC1,
+        4,
+        sensor_id,
+        day,
+        time_ticks,
+        0xFF,
+        0x01,
+    )
+    payload = struct.pack(
+        ">iii hhh hhh".replace(" ", ""),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    return header + payload
+
+
+def test_ingest_async_awaits_async_publisher() -> None:
+    class Recorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, bytes, dict[str, str] | None, float | None]] = []
+
+        async def publish(
+            self,
+            subject: str,
+            payload: bytes,
+            *,
+            headers: dict[str, str] | None = None,
+            timestamp: float | None = None,
+        ) -> None:
+            await asyncio.sleep(0)
+            self.calls.append((subject, payload, headers, timestamp))
+
+    publisher = Recorder()
+    producer = TSPIProducer(publisher)
+    datagram = _geocentric_datagram(sensor_id=42, time_ticks=12_345)
+
+    async def _exercise() -> None:
+        payload = await producer.ingest_async(datagram, recv_time=1_700_000_000.0)
+
+        assert payload is not None
+        assert publisher.calls
+        subject, encoded, headers, timestamp = publisher.calls[0]
+        assert subject == "tspi.geocentric.42"
+        assert headers and "Nats-Msg-Id" in headers
+        assert timestamp == 1_700_000_000.0
+        assert payload["sensor_id"] == 42
+
+    asyncio.run(_exercise())
+
+
+def test_ingest_filters_sensor_ids() -> None:
+    stream = InMemoryJetStream()
+    producer = TSPIProducer(stream, allowed_sensors={123})
+
+    datagram = _geocentric_datagram(sensor_id=456)
+    result = producer.ingest(datagram, recv_time=1_700_000_500.0)
+
+    assert result is None
+    consumer = stream.create_consumer(">")
+    assert consumer.pull(1) == []
+
+
+def test_udp_protocol_dispatches_to_producer() -> None:
+    calls: list[bytes] = []
+
+    class DummyProducer:
+        async def ingest_async(self, datagram: bytes, *, recv_time: float | None = None) -> None:
+            calls.append(datagram)
+
+    async def _exercise() -> None:
+        protocol = UDPIngestProtocol(DummyProducer())
+        protocol.datagram_received(b"packet", ("127.0.0.1", 12345))
+
+        await asyncio.sleep(0)
+        assert calls == [b"packet"]
+        await protocol.drain()
+
+    asyncio.run(_exercise())
+
+
+def test_async_publisher_passes_timeout() -> None:
+    class FakeJetStream:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, ...]] = []
+
+        async def publish(self, subject: str, payload: bytes, *, headers=None, timeout=None) -> None:
+            self.calls.append((subject, payload, headers, timeout))
+
+    jetstream = FakeJetStream()
+    publisher = AsyncJetStreamPublisher(jetstream, publish_timeout=3.5)
+
+    async def _exercise() -> None:
+        await publisher.publish("tspi.test", b"data", headers={"X": "1"})
+
+    asyncio.run(_exercise())
+
+    assert jetstream.calls == [("tspi.test", b"data", {"X": "1"}, 3.5)]

--- a/tspi_kit/producer.py
+++ b/tspi_kit/producer.py
@@ -1,8 +1,9 @@
-"""Headless TSPI producer that publishes to an in-memory JetStream."""
+"""Headless TSPI producer that publishes to JetStream."""
 from __future__ import annotations
 
+import inspect
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional, Set, Tuple
 
 import time
 
@@ -15,9 +16,18 @@ from .jetstream import build_subject, message_headers
 class TSPIProducer:
     """Parse raw TSPI datagrams and publish CBOR payloads."""
 
-    def __init__(self, publisher, *, stream_prefix: str = "tspi") -> None:
+    def __init__(
+        self,
+        publisher,
+        *,
+        stream_prefix: str = "tspi",
+        allowed_sensors: Optional[Iterable[int]] = None,
+    ) -> None:
         self._publisher = publisher
         self._stream_prefix = stream_prefix
+        self._allowed_sensors: Optional[Set[int]] = (
+            set(allowed_sensors) if allowed_sensors is not None else None
+        )
 
     def _encode_payload(self, parsed: ParsedTSPI, recv_time: float) -> Dict[str, object]:
         recv_epoch_ms = int(round(recv_time * 1000))
@@ -35,14 +45,45 @@ class TSPIProducer:
         }
         return payload
 
-    def ingest(self, datagram: bytes, *, recv_time: Optional[float] = None) -> Dict[str, object]:
+    def _prepare_message(
+        self, datagram: bytes, recv_time: float
+    ) -> Optional[Tuple[str, Dict[str, str], bytes, Dict[str, object]]]:
         parsed = parse_tspi_datagram(datagram)
-        recv_time = recv_time if recv_time is not None else time.time()
-        payload = self._encode_payload(parsed, recv_time)
 
+        if self._allowed_sensors is not None and parsed.sensor_id not in self._allowed_sensors:
+            return None
+
+        payload = self._encode_payload(parsed, recv_time)
         subject = build_subject(parsed, stream_prefix=self._stream_prefix)
         headers = message_headers(parsed)
-
         encoded = cbor2.dumps(payload)
+        return subject, headers, encoded, payload
+
+    def ingest(self, datagram: bytes, *, recv_time: Optional[float] = None) -> Optional[Dict[str, object]]:
+        recv_time = recv_time if recv_time is not None else time.time()
+        message = self._prepare_message(datagram, recv_time)
+        if message is None:
+            return None
+
+        subject, headers, encoded, payload = message
         self._publisher.publish(subject, encoded, headers=headers, timestamp=recv_time)
+        return payload
+
+    async def ingest_async(
+        self, datagram: bytes, *, recv_time: Optional[float] = None
+    ) -> Optional[Dict[str, object]]:
+        recv_time = recv_time if recv_time is not None else time.time()
+        message = self._prepare_message(datagram, recv_time)
+        if message is None:
+            return None
+
+        subject, headers, encoded, payload = message
+        result = self._publisher.publish(
+            subject,
+            encoded,
+            headers=headers,
+            timestamp=recv_time,
+        )
+        if inspect.isawaitable(result):
+            await result
         return payload

--- a/tspi_kit/udp_ingest.py
+++ b/tspi_kit/udp_ingest.py
@@ -1,0 +1,72 @@
+"""Async UDP ingestion helpers for the standalone TSPI producer."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+
+class UDPIngestProtocol(asyncio.DatagramProtocol):
+    """Receive UDP datagrams and hand them to a TSPI producer."""
+
+    def __init__(self, producer, *, loop: Optional[asyncio.AbstractEventLoop] = None, logger=None) -> None:
+        self._producer = producer
+        self._loop = loop or asyncio.get_running_loop()
+        self._logger = logger or logging.getLogger(__name__)
+        self._pending: set[asyncio.Task[None]] = set()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:  # pragma: no cover - logging only
+        sockname = transport.get_extra_info("sockname")
+        self._logger.info("Listening for TSPI datagrams on %s", sockname)
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:  # pragma: no cover - logging only
+        if exc:
+            self._logger.error("UDP listener stopped due to error: %s", exc)
+        else:
+            self._logger.info("UDP listener stopped")
+
+    def error_received(self, exc: Exception) -> None:  # pragma: no cover - logging only
+        self._logger.warning("UDP socket reported error: %s", exc)
+
+    def datagram_received(self, data: bytes, addr) -> None:
+        recv_time = time.time()
+        task = self._loop.create_task(self._ingest(data, recv_time))
+        self._pending.add(task)
+        task.add_done_callback(self._pending.discard)
+
+    async def _ingest(self, datagram: bytes, recv_time: float) -> None:
+        try:
+            await self._producer.ingest_async(datagram, recv_time=recv_time)
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("Failed to ingest TSPI datagram")
+
+    async def drain(self) -> None:
+        if not self._pending:
+            return
+
+        await asyncio.gather(*self._pending, return_exceptions=True)
+        self._pending.clear()
+
+
+class AsyncJetStreamPublisher:
+    """Adapter that proxies publish calls to an async JetStream context."""
+
+    def __init__(self, jetstream, *, publish_timeout: float = 2.0) -> None:
+        self._jetstream = jetstream
+        self._publish_timeout = publish_timeout
+
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        headers: Optional[dict[str, str]] = None,
+        timestamp: Optional[float] = None,  # noqa: ARG002 - kept for compatibility
+    ) -> None:
+        await self._jetstream.publish(
+            subject,
+            payload,
+            headers=headers,
+            timeout=self._publish_timeout,
+        )


### PR DESCRIPTION
## Summary
- add a standalone asyncio-based `producer.py` CLI that listens for TSPI UDP datagrams and publishes them to JetStream
- extend the core producer to support sensor filtering and asynchronous publishers, plus provide reusable UDP ingestion helpers
- refresh the documentation and add tests for the UDP ingest path to close the producer/spec gap

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7de80f22c832990e1ef9dfe5b0f52