### PR TITLE
Align docs around unified player/receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Open-source Python toolkit for working with FMV BAPS Realtime TSPI v4 telemetry.
 
 ## Features
 - **Producer** – UDP listener that parses TSPI datagrams, adds receive timestamps, and publishes CBOR payloads to JetStream with deduplication headers.
-- **Receiver** – Durable JetStream consumer that decodes CBOR, validates against the Draft 2020-12 schema, and emits JSON lines or logs.
-- **JetStream Player** – Unified Qt5 application (GUI/headless) with live ↔ historical source switching, timeline scrubbing, rate control, metrics, and smoothed map previews.
+- **Player/Receiver** – Single Qt5/CLI application that consumes JetStream telemetry, validates CBOR against the Draft 2020-12 schema, offers JSON/headless streaming, and provides live ↔ historical playback with timeline scrubbing, rate control, metrics, and smoothed map previews.
 - **PCAP Replayer** – Utility to ingest 37-byte TSPI captures and push them into the JetStream pipeline for offline testing.
 - **TSPI Generator** – Synthetic flight track generator (normal or airshow) targeting UDP or JetStream outputs with configurable fleet size/rates and headless automation.
 - **Schema & Tests** – Draft 2020-12 schema (`tspi.schema.json`) and pytest suite covering datagram parsing and schema validation.
@@ -39,9 +38,9 @@ pip install -e .[ui]
    ```bash
    python tspi_generator_qt.py --headless --nats-server nats://127.0.0.1:4222 --duration 10
    ```
-4. **Play back in headless mode**
+4. **Consume and play back telemetry**
    ```bash
-   python player_qt.py --headless --source live --nats-server nats://127.0.0.1:4222 --duration 10
+   python player_qt.py --headless --source live --nats-server nats://127.0.0.1:4222 --duration 10 --json-stream
    ```
 
 ## Components
@@ -53,14 +52,9 @@ pip install -e .[ui]
 - Options: sensor filters (`--sensor-id`), custom stream prefix, multiple NATS servers,
   publish timeout, log level
 
-### receiver.py
-- Durable consumer on `tspi.>`
-- Decodes CBOR to JSON, optional schema validation
-- Emits JSON lines by default (toggle with `--json-stream/--no-json-stream`)
-- Batch pull with back-off on idle
-
 ### player_qt.py
 - Unified GUI/headless JetStream receiver with live vs historical source selector
+- Optional JSON line output (`--json-stream/--no-json-stream`) for headless log pipelines
 - Timeline scrubber supports "YouTube-style" scrolling through buffered frames
 - Flags: `--headless`, `--source`, `--rate`, `--clock`, `--room`, `--metrics-interval`, `--exit-on-idle`
 

--- a/docs/player_receiver_jetstream.md
+++ b/docs/player_receiver_jetstream.md
@@ -58,6 +58,7 @@
 * Features:
   * Source selector for Live (JetStream) vs Historical (Datastore via Replayer).
   * Timeline scrubber ("YouTube" style) maintains a rolling history window for rewind/playhead jumps.
+  * Headless mode offers JSON line streaming to integrate with log pipelines.
   * Commands apply immediately and cache global state.
   * Tags display new annotations and support "seek to tag" for replay.
   * On startup, query TimescaleDB for the latest command and recent tags.

--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -6,13 +6,9 @@ This document captures the current discrepancies between the published specifica
 ## Producer / Ingestion Pipeline
 - ✅ `producer.py` now exists as a standalone asyncio CLI. It binds to UDP, parses TSPI datagrams with `TSPIProducer`, and publishes to JetStream using the official NATS client, matching both the README and change specification.【F:producer.py†L1-L109】【F:README.md†L6-L45】
 
-## Receiver / Consumer
-- **README expectation:** `receiver.py` is a durable JetStream consumer CLI with toggles for JSON streaming (`--json-stream/--no-json-stream`).【F:README.md†L55-L59】
-- **Implementation reality:** `tspi_kit.receiver.TSPIReceiver` is a thin wrapper around a provided consumer object with `fetch` helpers; there is no CLI, batching/back-off logic, or output streaming options.【F:tspi_kit/receiver.py†L1-L35】
-
-## Player (GUI/Headless)
-- **README expectation:** `player_qt.py` connects to a live JetStream cluster (via `--nats-server`), supports live ↔ historical switching, and exposes numerous CLI flags for remote connectivity.【F:README.md†L61-L65】【F:README.md†L42-L45】 The spec further requires direct JetStream subscriptions (`tspi.>`, `cmd.display.units`, `tags.broadcast`, `player.<room>.playout`) plus TimescaleDB lookups for commands/tags and unit conversions.【F:docs/player_receiver_jetstream.md†L50-L69】
-- **Implementation reality:** `player_qt.py` only accepts local playback options, instantiates an **in-memory** JetStream (`connect_in_memory`) and never reaches out to NATS or TimescaleDB. There are no command/tag subscriptions or unit conversion features in the player state machine.【F:player_qt.py†L14-L55】【F:tspi_kit/ui/player.py†L1-L200】【F:tspi_kit/ui/player.py†L452-L466】
+## Player/Receiver (GUI/Headless)
+- **README expectation:** `player_qt.py` serves as the unified player/receiver CLI, handling JSON line output, live ↔ historical switching, and direct JetStream connectivity via `--nats-server`.【F:README.md†L7-L13】【F:README.md†L43-L45】【F:README.md†L52-L55】 The change specification further requires JetStream subscriptions (`tspi.>`, `cmd.display.units`, `tags.broadcast`, `player.<room>.playout`) plus TimescaleDB lookups for commands/tags and unit conversions.【F:docs/player_receiver_jetstream.md†L50-L69】
+- **Implementation reality:** `player_qt.py` only accepts local playback options, instantiates an **in-memory** JetStream (`connect_in_memory`) and never reaches out to NATS or TimescaleDB. There are no command/tag subscriptions or unit conversion features in the player state machine. JSON output toggles are not exposed by the CLI; the feature exists solely in documentation.【F:player_qt.py†L14-L55】【F:tspi_kit/ui/player.py†L1-L200】【F:tspi_kit/ui/player.py†L452-L466】
 
 ## Generator
 - **README expectation:** `tspi_generator_qt.py` can emit UDP datagrams and/or publish directly to JetStream for downstream consumers.【F:README.md†L66-L70】


### PR DESCRIPTION
## Summary
- update the README to describe player_qt.py as the combined player/receiver CLI and adjust quick start instructions
- clarify the JetStream change specification with headless JSON streaming support for the unified app
- refresh the spec gap analysis to reference the combined player/receiver expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e352c8a483299158086f661bc21b