### PR TITLE
Fix JetStream capitalization in TSPI producer docs

### DIFF
--- a/producer.py
+++ b/producer.py
@@ -1,4 +1,4 @@
-"""Standalone UDP → JetStream TSPI producer."""
+"""Standalone UDP → JetStream TSPI to JetStream producer."""
 from __future__ import annotations
 
 import argparse
@@ -15,7 +15,9 @@ from tspi_kit.udp_ingest import AsyncJetStreamPublisher, UDPIngestProtocol
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="UDP TSPI producer for JetStream")
+    parser = argparse.ArgumentParser(
+        description="UDP TSPI to JetStream producer for JetStream"
+    )
     parser.add_argument(
         "--udp-host",
         default="0.0.0.0",

--- a/tspi_kit/producer.py
+++ b/tspi_kit/producer.py
@@ -1,4 +1,4 @@
-"""Headless TSPI producer that publishes to JetStream."""
+"""Headless TSPI to JetStream producer that publishes to JetStream."""
 from __future__ import annotations
 
 import inspect

--- a/tspi_kit/udp_ingest.py
+++ b/tspi_kit/udp_ingest.py
@@ -1,4 +1,4 @@
-"""Async UDP ingestion helpers for the standalone TSPI producer."""
+"""Async UDP ingestion helpers for the standalone TSPI to JetStream producer."""
 from __future__ import annotations
 
 import asyncio
@@ -8,7 +8,7 @@ from typing import Optional
 
 
 class UDPIngestProtocol(asyncio.DatagramProtocol):
-    """Receive UDP datagrams and hand them to a TSPI producer."""
+    """Receive UDP datagrams and hand them to a TSPI to JetStream producer."""
 
     def __init__(self, producer, *, loop: Optional[asyncio.AbstractEventLoop] = None, logger=None) -> None:
         self._producer = producer


### PR DESCRIPTION
## Summary
- correct the TSPI to JetStream producer terminology in the CLI description
- align supporting module docstrings with the TSPI to JetStream name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d812d8623883299755f3ebc6449e74