### PR TITLE
Add command sender console and integrate display commands

### DIFF
--- a/demo
+++ b/demo
@@ -19,6 +19,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
+from tspi_kit.commands import COMMAND_SUBJECT_PREFIX
 from tspi_kit.datastore import MessageRecord, TagRecord
 
 PROJECT_ROOT = Path(__file__).resolve().parent
@@ -526,7 +527,7 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     async def prepare_stream(js, replicas: int) -> None:
         stream_name = "TSPI"
-        subjects = ["tspi.>"]
+        subjects = ["tspi.>", f"{COMMAND_SUBJECT_PREFIX}.>", "tags.>"]
         try:
             await js.stream_info(stream_name)
             await js.update_stream({"name": stream_name, "subjects": subjects, "num_replicas": replicas})
@@ -550,6 +551,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         datastore_cluster: TimescaleHACluster | None = None
         archiver_task: asyncio.Task[None] | None = None
         generator_proc: subprocess.Popen[str] | None = None
+        command_proc: subprocess.Popen[str] | None = None
         player_proc: subprocess.Popen[str] | None = None
         stop_event = threading.Event()
         shutdown_event = asyncio.Event()
@@ -640,6 +642,19 @@ def main(argv: Iterable[str] | None = None) -> int:
                 for url in cluster.client_urls:
                     player_cmd.extend(["--nats-server", url])
 
+                command_cmd: List[str] = [
+                    sys.executable,
+                    str(PROJECT_ROOT / "tspi_command_qt.py"),
+                    "--sender-id",
+                    "demo-ui",
+                    "--js-stream",
+                    "TSPI",
+                    "--stream-prefix",
+                    "tspi",
+                ]
+                for url in cluster.client_urls:
+                    command_cmd.extend(["--nats-server", url])
+
                 try:
                     generator_proc = subprocess.Popen(generator_cmd, env=qt_env)
                     print(f"Launched generator UI: {shlex.join(generator_cmd)}", flush=True)
@@ -652,7 +667,18 @@ def main(argv: Iterable[str] | None = None) -> int:
                 except Exception as exc:
                     if generator_proc is not None and generator_proc.poll() is None:
                         generator_proc.terminate()
+                    if command_proc is not None and command_proc.poll() is None:
+                        command_proc.terminate()
                     raise RuntimeError(f"Failed to launch receiver UI: {exc}") from exc
+
+                try:
+                    command_proc = subprocess.Popen(command_cmd, env=qt_env)
+                    print(f"Launched command UI: {shlex.join(command_cmd)}", flush=True)
+                except Exception as exc:
+                    for proc in (player_proc, generator_proc):
+                        if proc is not None and proc.poll() is None:
+                            proc.terminate()
+                    raise RuntimeError(f"Failed to launch command UI: {exc}") from exc
 
                 async def monitor_process(name: str, proc: subprocess.Popen[str]) -> None:
                     await asyncio.to_thread(proc.wait)
@@ -662,6 +688,7 @@ def main(argv: Iterable[str] | None = None) -> int:
 
                 loop.create_task(monitor_process("Generator UI", generator_proc))
                 loop.create_task(monitor_process("Receiver UI", player_proc))
+                loop.create_task(monitor_process("Command UI", command_proc))
 
                 def request_shutdown() -> None:
                     if not shutdown_event.is_set():
@@ -686,7 +713,11 @@ def main(argv: Iterable[str] | None = None) -> int:
                 await shutdown_event.wait()
             finally:
                 stop_event.set()
-                for name, proc in (("generator UI", generator_proc), ("receiver UI", player_proc)):
+                for name, proc in (
+                    ("generator UI", generator_proc),
+                    ("receiver UI", player_proc),
+                    ("command UI", command_proc),
+                ):
                     if proc is None:
                         continue
                     if proc.poll() is None:

--- a/tests/test_ui_player.py
+++ b/tests/test_ui_player.py
@@ -7,7 +7,7 @@ import struct
 import pytest
 from PyQt5 import QtCore
 
-from tspi_kit import InMemoryJetStream, TSPIProducer
+from tspi_kit import CommandSender, InMemoryJetStream, TSPIProducer
 from tspi_kit.receiver import TSPIReceiver
 from tspi_kit.ui import JetStreamPlayerWindow
 
@@ -89,3 +89,48 @@ def test_map_smoothing(populated_player, qtbot):
     delta_first = abs(second_state.center[0] - first_state.center[0])
     delta_second = abs(third_state.center[0] - second_state.center[0])
     assert delta_second < delta_first
+
+
+def test_player_applies_display_commands(qtbot):
+    stream = InMemoryJetStream()
+    producer = TSPIProducer(stream)
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    header = struct.pack(
+        ">BBHHIBH",
+        0xC1,
+        4,
+        501,
+        200,
+        10_000,
+        0xFF,
+        0x01,
+    )
+    payload = struct.pack(
+        ">iii hhh hhh".replace(" ", ""),
+        int(100.0 * 1),
+        int(200.0 * 1),
+        int(300.0 * 1),
+        int(10.0 * 100),
+        int(5.0 * 100),
+        int(2.0 * 100),
+        int(0.5 * 100),
+        int(0.25 * 100),
+        int(0.1 * 100),
+    )
+    producer.ingest(header + payload, recv_time=base.timestamp())
+    sender = CommandSender(stream, sender_id="test-ui")
+    sender.send_units("imperial")
+    sender.send_marker_color("#123456")
+    consumer = stream.create_consumer("tspi.>")
+    receiver = TSPIReceiver(consumer)
+    window = JetStreamPlayerWindow(receiver)
+    qtbot.addWidget(window)
+    window.state.preload(batch=10)
+    qtbot.mouseClick(window.play_button, QtCore.Qt.LeftButton)
+    for _ in range(window.state.timeline_length()):
+        window.step_once()
+    assert window.state.display_units == "imperial"
+    assert window.state.marker_color == "#123456"
+    assert window.map_widget.marker_color == "#123456"
+    assert "imperial" in window._units_label.text()
+    assert "#123456" in window._marker_label.text()

--- a/tspi_command_qt.py
+++ b/tspi_command_qt.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Tuple
+
+from PyQt5 import QtCore, QtWidgets
+
+from tspi_kit.commands import COMMAND_SUBJECT_PREFIX, CommandSender
+from tspi_kit.jetstream_client import JetStreamThreadedClient
+from tspi_kit.ui.player import connect_in_memory, ensure_offscreen
+
+
+_COLOR_CHOICES: List[Tuple[str, str]] = [
+    ("Green", "#00ff00"),
+    ("Red", "#ff0000"),
+    ("Blue", "#0000ff"),
+    ("Magenta", "#ff00ff"),
+    ("Yellow", "#ffff00"),
+]
+
+
+class CommandController(QtCore.QObject):
+    status_changed = QtCore.pyqtSignal(str)
+    error_occurred = QtCore.pyqtSignal(str)
+
+    def __init__(self, sender: CommandSender) -> None:
+        super().__init__()
+        self._sender = sender
+
+    def set_units(self, units: str) -> None:
+        try:
+            payload = self._sender.send_units(units)
+        except Exception as exc:  # pragma: no cover - surface to UI
+            self.error_occurred.emit(str(exc))
+            return
+        self.status_changed.emit(f"Units set to {payload.payload['units']}")
+
+    def set_marker_color(self, color: str) -> None:
+        try:
+            payload = self._sender.send_marker_color(color)
+        except Exception as exc:  # pragma: no cover - surface to UI
+            self.error_occurred.emit(str(exc))
+            return
+        self.status_changed.emit(f"Marker color set to {payload.payload['marker_color']}")
+
+
+class CommandWindow(QtWidgets.QWidget):
+    def __init__(self, controller: CommandController) -> None:
+        super().__init__()
+        self._controller = controller
+        self.setWindowTitle("TSPI Command Console")
+        layout = QtWidgets.QVBoxLayout(self)
+
+        units_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(units_layout)
+        units_layout.addWidget(QtWidgets.QLabel("Display Units", self))
+        self._units_combo = QtWidgets.QComboBox(self)
+        self._units_combo.addItems(["metric", "imperial"])
+        units_layout.addWidget(self._units_combo)
+        units_button = QtWidgets.QPushButton("Send", self)
+        units_layout.addWidget(units_button)
+
+        colors_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(colors_layout)
+        colors_layout.addWidget(QtWidgets.QLabel("Marker Color", self))
+        self._color_combo = QtWidgets.QComboBox(self)
+        for name, value in _COLOR_CHOICES:
+            self._color_combo.addItem(f"{name} ({value})", value)
+        colors_layout.addWidget(self._color_combo)
+        color_button = QtWidgets.QPushButton("Send", self)
+        colors_layout.addWidget(color_button)
+
+        self._status_label = QtWidgets.QLabel("Ready", self)
+        layout.addWidget(self._status_label)
+
+        units_button.clicked.connect(self._send_units)
+        color_button.clicked.connect(self._send_color)
+        controller.status_changed.connect(self._show_status)
+        controller.error_occurred.connect(self._show_error)
+
+    def _send_units(self) -> None:
+        units = self._units_combo.currentText()
+        self._controller.set_units(units)
+
+    def _send_color(self) -> None:
+        color = self._color_combo.currentData()
+        if isinstance(color, str):
+            self._controller.set_marker_color(color)
+
+    def _show_status(self, message: str) -> None:
+        self._status_label.setText(message)
+
+    def _show_error(self, message: str) -> None:
+        self._status_label.setText(f"Error: {message}")
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TSPI Command Console")
+    parser.add_argument("--headless", action="store_true", help="Run without a GUI")
+    parser.add_argument("--sender-id", default="command-ui")
+    parser.add_argument("--units", choices=["metric", "imperial"])
+    parser.add_argument("--marker-color")
+    parser.add_argument(
+        "--nats-server",
+        dest="nats_servers",
+        action="append",
+        help="NATS server URL (may be provided multiple times).",
+    )
+    parser.add_argument("--js-stream", default="TSPI")
+    parser.add_argument("--stream-prefix", default="tspi")
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    ensure_offscreen(args.headless)
+    js_client: JetStreamThreadedClient | None = None
+
+    if args.nats_servers:
+        js_client = JetStreamThreadedClient(args.nats_servers)
+        js_client.start()
+        subjects = [
+            f"{args.stream_prefix}.>",
+            f"{COMMAND_SUBJECT_PREFIX}.>",
+            "tags.>",
+        ]
+        js_client.ensure_stream(args.js_stream, subjects)
+        publisher = js_client.publisher()
+    else:
+        stream, _ = connect_in_memory({"live": "tspi.>"})
+        publisher = stream
+
+    sender = CommandSender(publisher, sender_id=args.sender_id)
+
+    if args.headless:
+        if not args.units and not args.marker_color:
+            raise SystemExit("Headless mode requires --units and/or --marker-color")
+        if args.units:
+            sender.send_units(args.units)
+        if args.marker_color:
+            sender.send_marker_color(args.marker_color)
+        if js_client is not None:
+            js_client.close()
+        return 0
+
+    app = QtWidgets.QApplication(sys.argv)
+    if js_client is not None:
+        app.aboutToQuit.connect(js_client.close)
+    controller = CommandController(sender)
+    window = CommandWindow(controller)
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tspi_generator_qt.py
+++ b/tspi_generator_qt.py
@@ -6,6 +6,7 @@ import sys
 
 from PyQt5 import QtCore, QtWidgets
 
+from tspi_kit.commands import COMMAND_SUBJECT_PREFIX
 from tspi_kit.generator import FlightConfig, TSPIFlightGenerator
 from tspi_kit.jetstream_client import JetStreamThreadedClient
 from tspi_kit.producer import TSPIProducer
@@ -58,7 +59,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.nats_servers:
         js_client = JetStreamThreadedClient(args.nats_servers)
         js_client.start()
-        js_client.ensure_stream(args.js_stream, [f"{args.stream_prefix}.>"], num_replicas=args.stream_replicas)
+        subjects = [
+            f"{args.stream_prefix}.>",
+            f"{COMMAND_SUBJECT_PREFIX}.>",
+            "tags.>",
+        ]
+        js_client.ensure_stream(args.js_stream, subjects, num_replicas=args.stream_replicas)
         publisher = js_client.publisher()
     else:
         stream, _sources = connect_in_memory({"live": "tspi.>"})

--- a/tspi_kit/__init__.py
+++ b/tspi_kit/__init__.py
@@ -10,6 +10,7 @@ from .pcap import PCAPReplayer
 from .generator import FlightConfig, TSPIFlightGenerator
 from .datastore import TimescaleDatastore, MessageRecord, TagRecord
 from .archiver import Archiver
+from .commands import CommandSender, CommandPayload, COMMAND_SUBJECT_PREFIX
 from .replayer import StoreReplayer
 from .ui import (
     GeneratorController,
@@ -40,6 +41,9 @@ __all__ = [
     "MessageRecord",
     "TagRecord",
     "Archiver",
+    "CommandSender",
+    "CommandPayload",
+    "COMMAND_SUBJECT_PREFIX",
     "StoreReplayer",
     "UiConfig",
     "MapSmoother",

--- a/tspi_kit/commands.py
+++ b/tspi_kit/commands.py
@@ -1,0 +1,85 @@
+"""Utilities for constructing and publishing TSPI command messages."""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Dict
+
+import cbor2
+
+COMMAND_SUBJECT_PREFIX = "tspi.cmd.display"
+
+
+@dataclass(slots=True)
+class CommandPayload:
+    """Structured representation of a display command."""
+
+    cmd_id: str
+    name: str
+    ts: str
+    sender: str
+    payload: Dict[str, object]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "cmd_id": self.cmd_id,
+            "name": self.name,
+            "ts": self.ts,
+            "sender": self.sender,
+            "payload": dict(self.payload),
+        }
+
+
+class CommandSender:
+    """Publish display commands to JetStream-compatible publishers."""
+
+    def __init__(self, publisher, *, sender_id: str = "command-ui") -> None:
+        self._publisher = publisher
+        self._sender_id = sender_id
+
+    @staticmethod
+    def _timestamp() -> str:
+        return datetime.now(tz=UTC).isoformat()
+
+    def _publish(self, subject: str, payload: CommandPayload) -> CommandPayload:
+        encoded = cbor2.dumps(payload.to_dict())
+        headers = {"Nats-Msg-Id": payload.cmd_id}
+        result = self._publisher.publish(subject, encoded, headers=headers, timestamp=time.time())
+        if result is False:
+            raise RuntimeError(f"Failed to publish command {payload.cmd_id}")
+        return payload
+
+    def _build(self, name: str, body: Dict[str, object]) -> CommandPayload:
+        return CommandPayload(
+            cmd_id=str(uuid.uuid4()),
+            name=name,
+            ts=self._timestamp(),
+            sender=self._sender_id,
+            payload=body,
+        )
+
+    def send_units(self, units: str) -> CommandPayload:
+        """Publish a units command."""
+
+        normalized = units.lower()
+        if normalized not in {"metric", "imperial"}:
+            raise ValueError("Units must be 'metric' or 'imperial'")
+        payload = self._build("display.units", {"units": normalized})
+        subject = f"{COMMAND_SUBJECT_PREFIX}.units"
+        return self._publish(subject, payload)
+
+    def send_marker_color(self, color: str) -> CommandPayload:
+        """Publish a marker color command."""
+
+        if not color:
+            raise ValueError("Color must be a non-empty string")
+        normalized = color.strip()
+        body = {"marker_color": normalized}
+        payload = self._build("display.marker_color", body)
+        subject = f"{COMMAND_SUBJECT_PREFIX}.marker_color"
+        return self._publish(subject, payload)
+
+
+__all__ = ["CommandSender", "COMMAND_SUBJECT_PREFIX", "CommandPayload"]

--- a/tspi_kit/ui/config.py
+++ b/tspi_kit/ui/config.py
@@ -17,3 +17,5 @@ class UiConfig:
     default_rate: float = 1.0
     default_clock: str = "receive"
     scrub_history_size: int = 600
+    default_units: str = "metric"
+    default_marker_color: str = "#00ff00"

--- a/tspi_kit/ui/map.py
+++ b/tspi_kit/ui/map.py
@@ -48,22 +48,37 @@ class MapPreviewWidget(QtWidgets.QWidget):
     def __init__(self, smoother: MapSmoother, parent: Optional[QtWidgets.QWidget] = None) -> None:
         super().__init__(parent)
         self._smoother = smoother
-        self._label = QtWidgets.QLabel("Map Preview", self)
         layout = QtWidgets.QVBoxLayout(self)
-        layout.addWidget(self._label)
+        self._position_label = QtWidgets.QLabel("Map Preview", self)
+        layout.addWidget(self._position_label)
+        self._marker_color = "#00ff00"
+        self._marker_label = QtWidgets.QLabel("Marker: #00ff00", self)
+        layout.addWidget(self._marker_label)
         self._state = self._smoother.state
-        self._update_label()
+        self._update_position_label()
 
     @property
     def state(self) -> MapState:
         return self._state
 
+    @property
+    def marker_color(self) -> str:
+        return self._marker_color
+
     def apply_position(self, center: Tuple[float, float], zoom: float) -> MapState:
         self._state = self._smoother.update(center, zoom)
-        self._update_label()
+        self._update_position_label()
         self.state_changed.emit(self._state)
         return self._state
 
-    def _update_label(self) -> None:
+    def set_marker_color(self, color: str) -> None:
+        if not color:
+            return
+        self._marker_color = color
+        self._marker_label.setText(f"Marker: {color}")
+
+    def _update_position_label(self) -> None:
         center_x, center_y = self._state.center
-        self._label.setText(f"Center: {center_x:.2f}, {center_y:.2f} | Zoom: {self._state.zoom:.2f}")
+        self._position_label.setText(
+            f"Center: {center_x:.2f}, {center_y:.2f} | Zoom: {self._state.zoom:.2f}"
+        )


### PR DESCRIPTION
## Summary
- add a reusable command publishing helper and a Qt/CLI command console for unit and marker color updates
- teach the player UI and headless runner pipeline to consume display commands alongside telemetry and surface current units/marker color state
- expand the archiver/demo/tooling and documentation/tests so command traffic shares the TSPI replay path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d81dbd61288329af9ee61421ac4539