### PR TITLE
Update gap analysis to highlight outstanding inconsistencies

### DIFF
--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -1,25 +1,20 @@
 # Spec vs. Implementation Gap Analysis
 
 ## Overview
-This document captures the current discrepancies between the published specifications/README and the implementation that ships in this repository.
+The current repository diverges from the published specifications in several key areas. Installation instructions reference packaging metadata that is not present, several JetStream integration features remain unimplemented, and the generator CLI cannot fulfil the documented UDP workflow. The sections below capture the gaps that still need to be addressed.
 
-## Producer / Ingestion Pipeline
-- ✅ `producer.py` now exists as a standalone asyncio CLI. It binds to UDP, parses TSPI datagrams with `TSPIProducer`, and publishes to JetStream using the official NATS client, matching both the README and change specification.【F:producer.py†L1-L109】【F:README.md†L5-L54】
+## Installation & Packaging
+- ❌ The README directs contributors to install the toolkit via `pip install -e .[test]`, implying editable mode support backed by a `pyproject.toml` or equivalent packaging file.【F:README.md†L17-L36】 The repository root, however, does not ship any packaging metadata (no `pyproject.toml`, `setup.cfg`, or `setup.py`), so the editable install instructions cannot succeed as written.【fed0aa†L1-L4】
 
-## Quick Start / CLI Parity
-- ✅ `player_qt.py` and `tspi_generator_qt.py` now honour the documented `--nats-server` flag, establishing real JetStream connections with threaded adapters. The player exposes the documented `--json-stream/--no-json-stream` toggle, and both CLIs fall back to the in-memory simulator only when no server is supplied.【F:player_qt.py†L6-L83】【F:tspi_generator_qt.py†L6-L74】
+## TSPI Generator CLI
+- ❌ The README advertises that the TSPI generator can target “UDP datagrams and/or publishes directly to JetStream.”【F:README.md†L54-L71】 In practice the CLI only exposes JetStream connectivity (or the in-memory simulator); there are no arguments for UDP targets or sockets in `tspi_generator_qt.py`, so the UDP output path described in the spec is missing.【F:tspi_generator_qt.py†L1-L92】
 
-## Player/Receiver (GUI/Headless)
-- ✅ The player CLI builds durable JetStream consumers for live and historical subjects, allowing the GUI and headless runner to operate directly against external JetStream clusters. JSON streaming follows the README flag, and connections are closed cleanly when the application exits.【F:player_qt.py†L34-L98】
+## Player / Receiver Integration
+- ❌ The JetStream change specification requires the player to bootstrap from TimescaleDB (latest commands, recent tags) and to surface collaborative tag events with “seek to tag” support.【F:docs/player_receiver_jetstream.md†L37-L70】 The shipped player only instantiates JetStream consumers from the CLI, never touches the datastore, and routes messages exclusively through the in-memory/JetStream receivers.【F:player_qt.py†L14-L82】
+- ❌ Tag subjects (`tags.*`) are not consumed anywhere in the player window or headless runner, so tag broadcasts described in the spec cannot appear in the UI. `PlayerState._handle_message` distinguishes only telemetry vs. command payloads and lacks any tag-handling branch.【F:tspi_kit/ui/player.py†L109-L172】
 
-## Generator
-- ✅ The generator CLI can publish to JetStream by spinning up the same threaded client, optionally creating the telemetry stream before publishing. The legacy in-memory mode remains available for tests, but the README workflow using `--nats-server` now functions end to end. UI sessions can automatically repeat via the `--continuous/--no-continuous` toggle consumed by the demo helper.【F:tspi_generator_qt.py†L38-L120】
-
-## Persistence (Archiver, TimescaleDB, Replayer)
-- ✅ **Resolved:** The archiver consumes real JetStream pull subscriptions and persists into TimescaleDB via an asyncpg-backed client that mirrors the documented schema. Historical playback pulls the canonical records and republishes to `player.<room>.playout` with paced timing, matching the spec.【F:tspi_kit/archiver.py†L1-L94】【F:tspi_kit/datastore.py†L1-L227】【F:tspi_kit/replayer.py†L1-L88】
-
-## Demo helper
-- ✅ The `./demo` helper now delivers the promised experience: it spins up a three-node JetStream cluster, instantiates an in-memory two-node HA datastore for the archiver, launches the generator and unified receiver/player UIs against real JetStream traffic, and coordinates graceful shutdown alongside datastore persistence.【F:README.md†L82-L95】【F:demo†L1-L760】
+## Demo Environment Expectations
+- ⚠️ The README describes a demo helper that launches a three-node JetStream cluster, dual TimescaleDB nodes, and orchestrates generator/player lifecycles.【F:README.md†L82-L98】 While the bundled `demo` script exists, it still depends on the unreconciled features above (Timescale bootstrapping, full tag flow). Until those gaps are closed, the documented “full demonstration environment” will not match runtime behaviour.
 
 ## Summary
-The remaining toolkit components now align with the published README and JetStream integration specification. Producer, player, generator, and demo flows all operate against real JetStream clusters when requested while retaining in-memory shims for tests.【F:player_qt.py†L6-L106】【F:tspi_generator_qt.py†L6-L84】
+Significant mismatches remain between the published docs/spec and the implementation: editable installs fail due to missing packaging metadata, the generator cannot emit UDP traffic, and the player omits the datastore/tag integrations mandated by the JetStream specification. Addressing these areas should be prioritised before declaring the toolkit feature-complete.


### PR DESCRIPTION
## Summary
- refresh the spec-vs-code gap analysis to reflect the remaining discrepancies between the documentation and implementation
- call out missing packaging metadata, the generator's lack of UDP output, and absent player/tag datastore integrations
- note the knock-on effect these issues have on the documented demo workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d38802dc832987263b111c06bf69