### PR TITLE
Add UDP output options to TSPI generator CLI

### DIFF
--- a/tests/test_generator_cli.py
+++ b/tests/test_generator_cli.py
@@ -1,0 +1,28 @@
+"""Tests for the TSPI generator CLI argument parsing."""
+from __future__ import annotations
+
+import pytest
+
+from tspi_generator_qt import parse_args
+
+
+def test_parse_args_defaults() -> None:
+    args = parse_args([])
+    assert args.jetstream is True
+    assert args.udp_targets == []
+
+
+def test_parse_args_udp_targets() -> None:
+    args = parse_args(["--no-jetstream", "--udp-target", "127.0.0.1:45000"])
+    assert args.jetstream is False
+    assert args.udp_targets == [("127.0.0.1", 45000)]
+
+
+def test_parse_args_requires_output() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--no-jetstream"])
+
+
+def test_parse_args_invalid_udp_target() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--udp-target", "bad-target"])

--- a/tspi_generator_qt.py
+++ b/tspi_generator_qt.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import socket
 import sys
 
 from PyQt5 import QtCore, QtWidgets
 
 from tspi_kit.commands import COMMAND_SUBJECT_PREFIX
 from tspi_kit.generator import FlightConfig, TSPIFlightGenerator
-from tspi_kit.jetstream_client import JetStreamThreadedClient
 from tspi_kit.producer import TSPIProducer
 from tspi_kit.ui import GeneratorController
 from tspi_kit.ui.player import connect_in_memory, ensure_offscreen
@@ -48,35 +48,107 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Number of JetStream replicas when creating the stream.",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--jetstream",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable JetStream publishing (disabled via --no-jetstream).",
+    )
+    parser.add_argument(
+        "--udp-target",
+        dest="udp_targets",
+        action="append",
+        default=None,
+        metavar="HOST:PORT",
+        help="Send generated datagrams to the given UDP endpoint (repeatable).",
+    )
+
+    args = parser.parse_args(argv)
+
+    udp_targets: list[tuple[str, int]] = []
+    for target in args.udp_targets or []:
+        try:
+            host, port_str = target.rsplit(":", 1)
+            if not host or not port_str:
+                raise ValueError
+            port = int(port_str, 10)
+        except ValueError as exc:  # pragma: no cover - argparse error path
+            parser.error(f"Invalid UDP target '{target}'. Expected format HOST:PORT.")
+            raise SystemExit from exc
+        udp_targets.append((host, port))
+    args.udp_targets = udp_targets
+
+    if not args.jetstream and not args.udp_targets:
+        parser.error("At least one output must be enabled via --jetstream or --udp-target.")
+
+    return args
+
+
+class _MultiOutputProducer:
+    """Forward generated datagrams to JetStream and/or UDP sockets."""
+
+    def __init__(
+        self,
+        jetstream_producer: TSPIProducer | None,
+        udp_targets: list[tuple[str, int]],
+    ) -> None:
+        self._jetstream_producer = jetstream_producer
+        self._udp_targets = list(udp_targets)
+        self._udp_socket: socket.socket | None = None
+        if self._udp_targets:
+            self._udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def ingest(self, datagram: bytes, *, recv_time: float | None = None):
+        if self._udp_socket is not None:
+            for target in self._udp_targets:
+                self._udp_socket.sendto(datagram, target)
+        if self._jetstream_producer is not None:
+            return self._jetstream_producer.ingest(datagram, recv_time=recv_time)
+        return None
+
+    def close(self) -> None:
+        if self._udp_socket is not None:
+            self._udp_socket.close()
+            self._udp_socket = None
 
 
 def main(argv: list[str] | None = None) -> int:
+    from tspi_kit.jetstream_client import JetStreamThreadedClient
+
     args = parse_args(argv)
     ensure_offscreen(args.headless)
     js_client: JetStreamThreadedClient | None = None
+    publisher = None
+    if args.jetstream:
+        if args.nats_servers:
+            js_client = JetStreamThreadedClient(args.nats_servers)
+            js_client.start()
+            subjects = [
+                f"{args.stream_prefix}.>",
+                f"{COMMAND_SUBJECT_PREFIX}.>",
+                "tags.>",
+            ]
+            js_client.ensure_stream(
+                args.js_stream, subjects, num_replicas=args.stream_replicas
+            )
+            publisher = js_client.publisher()
+        else:
+            stream, _sources = connect_in_memory({"live": "tspi.>"})
+            publisher = stream
 
-    if args.nats_servers:
-        js_client = JetStreamThreadedClient(args.nats_servers)
-        js_client.start()
-        subjects = [
-            f"{args.stream_prefix}.>",
-            f"{COMMAND_SUBJECT_PREFIX}.>",
-            "tags.>",
-        ]
-        js_client.ensure_stream(args.js_stream, subjects, num_replicas=args.stream_replicas)
-        publisher = js_client.publisher()
-    else:
-        stream, _sources = connect_in_memory({"live": "tspi.>"})
-        publisher = stream
-
-    producer = TSPIProducer(publisher, stream_prefix=args.stream_prefix)
+    jetstream_producer = (
+        TSPIProducer(publisher, stream_prefix=args.stream_prefix)
+        if publisher is not None
+        else None
+    )
+    producer = _MultiOutputProducer(jetstream_producer, args.udp_targets)
     config = FlightConfig(count=args.count, rate_hz=args.rate)
     generator = TSPIFlightGenerator(config)
     controller = GeneratorController(generator, producer)
 
     if args.headless:
         controller.run(args.duration)
+        producer.close()
         if js_client is not None:
             js_client.close()
         return 0
@@ -101,6 +173,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         QtCore.QTimer.singleShot(0, run_once)
     exit_code = app.exec()
+    producer.close()
     if js_client is not None:
         js_client.close()
     return exit_code


### PR DESCRIPTION
## Summary
- add CLI switches to enable or disable JetStream publishing and configure UDP targets for the TSPI generator
- implement a multi-output producer so generated datagrams can be sent to UDP sockets alongside JetStream
- add unit tests covering the generator CLI argument validation

## Testing
- pytest tests/test_generator_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ff90e4188329b56d661b772699c1