### PR TITLE
Refresh spec gap analysis to match current implementation

### DIFF
--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -1,20 +1,41 @@
 # Spec vs. Implementation Gap Analysis
 
 ## Overview
-The current repository diverges from the published specifications in several key areas. Installation instructions reference packaging metadata that is not present, several JetStream integration features remain unimplemented, and the generator CLI cannot fulfil the documented UDP workflow. The sections below capture the gaps that still need to be addressed.
+The documentation and JetStream change specification now align with the packaging and
+telemetry publishing features that had previously been missing. However, several claims
+about TimescaleDB bootstrapping and generator ergonomics remain out of sync with the
+current implementation. The sections below capture both the resolved items and the gaps
+that still need attention.
 
-## Installation & Packaging
-- ✅ The README directs contributors to install the toolkit via `pip install -e .[test]`, implying editable mode support backed by a `pyproject.toml` or equivalent packaging file.【F:README.md†L17-L36】 The repository now includes a modern `pyproject.toml` that defines the package metadata, dependencies, and extras required by the documentation, allowing editable installs to succeed as described.【F:pyproject.toml†L1-L68】
+## Resolved discrepancies
+- ✅ The README's editable-install instructions are now backed by a fully populated
+  `pyproject.toml`, allowing `pip install -e .[test]` to succeed as written.【F:README.md†L17-L36】【F:pyproject.toml†L1-L68】
+- ✅ The TSPI generator actually supports the documented UDP workflow: `--udp-target`
+  arguments are parsed and forwarded alongside JetStream publishing when enabled.【F:README.md†L61-L66】【F:tspi_generator_qt.py†L17-L144】
+- ✅ Player components subscribe to `tags.broadcast` and route tag events through
+  `PlayerState._handle_tag`, matching the JetStream change specification's requirement
+  for collaborative tag support.【F:docs/player_receiver_jetstream.md†L51-L70】【F:player_qt.py†L38-L70】【F:tspi_kit/ui/player.py†L151-L343】
 
-## TSPI Generator CLI
-- ❌ The README advertises that the TSPI generator can target “UDP datagrams and/or publishes directly to JetStream.”【F:README.md†L54-L71】 In practice the CLI only exposes JetStream connectivity (or the in-memory simulator); there are no arguments for UDP targets or sockets in `tspi_generator_qt.py`, so the UDP output path described in the spec is missing.【F:tspi_generator_qt.py†L1-L92】
+## Outstanding inconsistencies
 
-## Player / Receiver Integration
-- ❌ The JetStream change specification requires the player to bootstrap from TimescaleDB (latest commands, recent tags) and to surface collaborative tag events with “seek to tag” support.【F:docs/player_receiver_jetstream.md†L37-L70】 The shipped player only instantiates JetStream consumers from the CLI, never touches the datastore, and routes messages exclusively through the in-memory/JetStream receivers.【F:player_qt.py†L14-L82】
-- ❌ Tag subjects (`tags.*`) are not consumed anywhere in the player window or headless runner, so tag broadcasts described in the spec cannot appear in the UI. `PlayerState._handle_message` distinguishes only telemetry vs. command payloads and lacks any tag-handling branch.【F:tspi_kit/ui/player.py†L109-L172】
+### TimescaleDB bootstrap for the player
+The JetStream change specification still mandates that the player "query TimescaleDB for
+the latest command and recent tags" during startup.【F:docs/player_receiver_jetstream.md†L58-L66】
+Neither `player_qt.py` nor the underlying `PlayerState` touch `TimescaleDatastore` or issue
+any database calls—they construct JetStream consumers only and maintain in-memory tag state
+populated from live subjects.【F:player_qt.py†L15-L109】【F:tspi_kit/ui/player.py†L140-L367】
+As a result, the documented datastore bootstrap remains unimplemented.
 
-## Demo Environment Expectations
-- ⚠️ The README describes a demo helper that launches a three-node JetStream cluster, dual TimescaleDB nodes, and orchestrates generator/player lifecycles.【F:README.md†L82-L98】 While the bundled `demo` script exists, it still depends on the unreconciled features above (Timescale bootstrapping, full tag flow). Until those gaps are closed, the documented “full demonstration environment” will not match runtime behaviour.
+### README generator feature list
+The README still advertises generator "Styles: `normal` and `airshow`" and
+"Headless metrics" output.【F:README.md†L61-L66】 The CLI exposes no style-related
+arguments, and the headless branch simply runs the controller before exiting without
+printing or streaming metrics.【F:tspi_generator_qt.py†L17-L154】 The existing generator
+API only produces a single deterministic flight pattern, so the README oversells the
+current feature set.
 
 ## Summary
-Significant mismatches remain between the published docs/spec and the implementation: editable installs fail due to missing packaging metadata, the generator cannot emit UDP traffic, and the player omits the datastore/tag integrations mandated by the JetStream specification. Addressing these areas should be prioritised before declaring the toolkit feature-complete.
+Packaging and JetStream publishing behaviour now match the published documentation, and
+collaborative tag handling is wired up as specified. The remaining misalignments centre
+on TimescaleDB bootstrapping for the player and the README's lingering claims about
+multiple generator styles and headless metrics output.


### PR DESCRIPTION
## Summary
- update the spec gap analysis document to note resolved packaging, generator, and tag handling items
- document the remaining gaps around TimescaleDB bootstrapping and the generator feature list in the README

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d90112679c8329bacce08844bf4d13