### PR TITLE
Document and replay command/tag events on seek

### DIFF
--- a/docs/player_receiver_jetstream.md
+++ b/docs/player_receiver_jetstream.md
@@ -60,7 +60,9 @@
   * Headless mode offers JSON line streaming to integrate with log pipelines.
   * Commands apply immediately and cache global state (units, marker color, ...).
   * Tags display new annotations and support "seek to tag" for replay.
-* On startup, query TimescaleDB for the latest command and recent tags.
+  * Command and tag panes only reflect events observed after startup; there is no TimescaleDB bootstrap step.
+  * When operators seek or scrub forward through historical data, the player replays every command and tag that occurred between the previous playhead and the new target before resuming telemetry frames.
+  * Historical playout feeds must include the commands and tags that precede a selected start point so the player can emit them before the first telemetry frame at that position.
 * Command messages share the same JetStream stream as TSPI telemetry to guarantee that archival and replay reproduce the exact sequence of events.
   * Conversion for display only (DB remains SI units):
     * Altitude: metres ↔ feet.

--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -15,16 +15,11 @@ that still need attention.
 - ✅ Player components subscribe to `tags.broadcast` and route tag events through
   `PlayerState._handle_tag`, matching the JetStream change specification's requirement
   for collaborative tag support.【F:docs/player_receiver_jetstream.md†L51-L70】【F:player_qt.py†L38-L70】【F:tspi_kit/ui/player.py†L151-L343】
+- ✅ The player specification now reflects in-session command/tag history: it no
+  longer promises a TimescaleDB bootstrap and documents the forward-seek replay
+  behaviour implemented in `PlayerState`.【F:docs/player_receiver_jetstream.md†L51-L80】【F:tspi_kit/ui/player.py†L151-L367】
 
 ## Outstanding inconsistencies
-
-### TimescaleDB bootstrap for the player
-The JetStream change specification still mandates that the player "query TimescaleDB for
-the latest command and recent tags" during startup.【F:docs/player_receiver_jetstream.md†L58-L66】
-Neither `player_qt.py` nor the underlying `PlayerState` touch `TimescaleDatastore` or issue
-any database calls—they construct JetStream consumers only and maintain in-memory tag state
-populated from live subjects.【F:player_qt.py†L15-L109】【F:tspi_kit/ui/player.py†L140-L367】
-As a result, the documented datastore bootstrap remains unimplemented.
 
 ### README generator feature list
 The README still advertises generator "Styles: `normal` and `airshow`" and
@@ -36,6 +31,6 @@ current feature set.
 
 ## Summary
 Packaging and JetStream publishing behaviour now match the published documentation, and
-collaborative tag handling is wired up as specified. The remaining misalignments centre
-on TimescaleDB bootstrapping for the player and the README's lingering claims about
-multiple generator styles and headless metrics output.
+collaborative tag handling is wired up as specified. Remaining misalignments are limited
+to the README's lingering claims about multiple generator styles and headless metrics
+output.


### PR DESCRIPTION
## Summary
- document that the player maintains in-session command/tag history and describe the replay expectations when scrubbing forward
- replay command and tag events in `PlayerState` whenever the playhead jumps ahead and cover the behaviour with a new UI test

## Testing
- pytest tests/test_ui_player.py

------
https://chatgpt.com/codex/tasks/task_e_68d904f3c738832987aa9d88d45ed400