### PR TITLE
Clarify documentation gaps around testing and map smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ The Draft 2020-12 schema in `tspi.schema.json` enforces shared fields (`type`, `
 ```bash
 pytest
 ```
-Tests cover datagram parsing for both message types, schema validation, non-UI integration flows, and Qt5 GUI/headless behaviour. Run `pytest -k ui` to focus on interface validation driven by `pytest-qt`.
+Tests cover datagram parsing for both message types, schema validation, non-UI integration flows, and Qt5 GUI/headless behaviour. A lightweight stub of the `pytest-qt` plugin ships with the repo so UI tests can execute without the real Qt event loop; install the `ui` extra if you want to exercise the applications against an actual Qt runtime. Run `pytest -k ui` to focus on the interface-oriented checks.
 
 ## Offline Maps
-Map previews currently use placeholder widgets. Final integration will use PyQtWebEngine/OSM tiles with configurable smoothing (`--smooth-center`, `--smooth-zoom`, `--window-sec`) exposed via shared UI configuration (`tspi_kit.ui.app.UiConfig`). Headless modes remain fully operational without map assets.
+Map previews currently use placeholder widgets. Planned PyQtWebEngine/OSM integration will reuse the existing `UiConfig` dataclass (`tspi_kit.ui.config.UiConfig`) which already exposes smoothing parameters such as `smooth_center`, `smooth_zoom`, and `window_sec`; these values are presently configured programmatically rather than through CLI flags. Headless modes remain fully operational without map assets.
 
 ## License
 Apache License 2.0 — see `LICENSE`.

--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -24,10 +24,17 @@ that still need attention.
 
 ## Outstanding inconsistencies
 
-None at this time.
+- ⚠️ The README's testing guidance still implies the upstream `pytest-qt` plugin drives the UI
+  suite even though the repository provides a lightweight stub implementation and disables the
+  real plugin via `pytest.ini`. The documentation should clarify that the stub is in place by
+  default and outline how to run the tests against a full Qt runtime when desired.【F:README.md†L69-L78】【F:pytest.ini†L1-L2】【F:pytestqt/plugin.py†L1-L31】
+- ⚠️ The README's offline maps section references CLI flags (`--smooth-center`, `--smooth-zoom`,
+  `--window-sec`) and the module `tspi_kit.ui.app.UiConfig`, but the smoothing parameters are only
+  available through the `UiConfig` dataclass in `tspi_kit.ui.config` and are not yet surfaced as
+  command-line options.【F:README.md†L81-L88】【F:tspi_kit/ui/config.py†L1-L20】
 
 ## Summary
 Packaging and JetStream publishing behaviour now match the published documentation, and
-collaborative tag handling is wired up as specified. Remaining misalignments are limited
-to the README's lingering claims about multiple generator styles and headless metrics
-output.
+collaborative tag handling is wired up as specified. Outstanding doc updates should focus
+on clarifying the bundled pytest-qt stub and the current entry points for map smoothing
+configuration.


### PR DESCRIPTION
## Summary
- clarify that the repository ships a lightweight pytest-qt stub and explain how it affects the documented test workflow
- correct the offline maps documentation to reference the UiConfig dataclass instead of undocumented CLI flags
- capture the outstanding documentation mismatches in the spec vs. code gap analysis

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d909f2c4dc8329819df531d4cc4a6e