### PR TITLE
Clarify pytest-qt usage and refresh gap analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ The Draft 2020-12 schema in `tspi.schema.json` enforces shared fields (`type`, `
 ```bash
 pytest
 ```
-Tests cover datagram parsing for both message types, schema validation, non-UI integration flows, and Qt5 GUI/headless behaviour. A lightweight stub of the `pytest-qt` plugin ships with the repo so UI tests can execute without the real Qt event loop; install the `ui` extra if you want to exercise the applications against an actual Qt runtime. Run `pytest -k ui` to focus on the interface-oriented checks.
+Tests cover datagram parsing for both message types, schema validation, non-UI integration flows, and Qt5 GUI/headless behaviour. A lightweight stub of the `pytest-qt` plugin ships with the repo so UI tests can execute without the real Qt event loop; the real plugin is disabled in `pytest.ini` via `-p no:pytestqt`. Install the `ui` extra (and `pytest-qt`) if you want to exercise the applications against an actual Qt runtime, then re-enable the real fixture set with:
+
+```bash
+PYTEST_ADDOPTS="" pytest -p pytestqt
+```
+
+Run `pytest -k ui` to focus on the interface-oriented checks once the desired plugin is active.
 
 ## Offline Maps
 Map previews currently use placeholder widgets. Planned PyQtWebEngine/OSM integration will reuse the existing `UiConfig` dataclass (`tspi_kit.ui.config.UiConfig`) which already exposes smoothing parameters such as `smooth_center`, `smooth_zoom`, and `window_sec`; these values are presently configured programmatically rather than through CLI flags. Headless modes remain fully operational without map assets.

--- a/docs/spec_vs_code_gap.md
+++ b/docs/spec_vs_code_gap.md
@@ -22,20 +22,13 @@ that still need attention.
   headless metrics output: `--style` toggles "normal" vs "airshow" formations
   and headless runs emit JSON metrics summarising frames, aircraft, and rate.【F:README.md†L61-L66】【F:tspi_generator_qt.py†L19-L148】【F:tspi_kit/generator.py†L10-L118】
 - ✅ The karaoke-style channel and replay specification now has a concrete implementation in `tspi_kit.channels`, and the README documents the helper APIs for operators and clients.【F:docs/channels-replay-spec.md†L1-L133】【F:tspi_kit/channels.py†L1-L295】【F:README.md†L9-L110】
+- ✅ The README's testing guidance now explains that the bundled `pytest-qt` stub is active by default and shows how to re-enable the upstream plugin when running against a full Qt runtime.【F:README.md†L69-L86】【F:pytest.ini†L1-L2】【F:pytestqt/plugin.py†L1-L31】
 
 ## Outstanding inconsistencies
 
-- ⚠️ The README's testing guidance still implies the upstream `pytest-qt` plugin drives the UI
-  suite even though the repository provides a lightweight stub implementation and disables the
-  real plugin via `pytest.ini`. The documentation should clarify that the stub is in place by
-  default and outline how to run the tests against a full Qt runtime when desired.【F:README.md†L69-L78】【F:pytest.ini†L1-L2】【F:pytestqt/plugin.py†L1-L31】
-- ⚠️ The README's offline maps section references CLI flags (`--smooth-center`, `--smooth-zoom`,
-  `--window-sec`) and the module `tspi_kit.ui.app.UiConfig`, but the smoothing parameters are only
-  available through the `UiConfig` dataclass in `tspi_kit.ui.config` and are not yet surfaced as
-  command-line options.【F:README.md†L81-L88】【F:tspi_kit/ui/config.py†L1-L20】
+None currently identified. Future updates should reassess once the offline map work or additional CLI surfaces ship.
 
 ## Summary
 Packaging and JetStream publishing behaviour now match the published documentation, and
-collaborative tag handling is wired up as specified. Outstanding doc updates should focus
-on clarifying the bundled pytest-qt stub and the current entry points for map smoothing
-configuration.
+collaborative tag handling is wired up as specified. No further documentation gaps are
+tracked at present, but the sheet should be revisited as new features land.


### PR DESCRIPTION
## Summary
- clarify the README testing section to explain the bundled pytest-qt stub and how to re-enable the real plugin
- update the spec-vs-code gap analysis to record the resolved pytest-qt documentation issue and note that no other gaps are open

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d971a841288329857b604f437de965