### PR TITLE
Normalize JetStream stream subjects

### DIFF
--- a/demo
+++ b/demo
@@ -21,6 +21,7 @@ from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 from tspi_kit.commands import COMMAND_SUBJECT_PREFIX
 from tspi_kit.datastore import MessageRecord, TagRecord
+from tspi_kit.jetstream_client import normalize_stream_subjects
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 APT_UPDATED = False
@@ -528,11 +529,9 @@ def main(argv: Iterable[str] | None = None) -> int:
     else:
         print("requirements.txt not found; skipping Python dependency check.")
 
+    from nats import errors as nats_errors
     from nats.aio.client import Client as NATS
-    try:
-        from nats.errors import ErrNoServers
-    except ImportError:  # pragma: no cover - compatibility with newer nats-py
-        from nats.errors import NoServersError as ErrNoServers  # type: ignore[attr-defined]
+    ErrNoServers = getattr(nats_errors, "ErrNoServers", nats_errors.NoServersError)
     from nats.js.errors import NotFoundError
     from tspi_kit.archiver import Archiver
 
@@ -558,10 +557,12 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     async def prepare_stream(js, replicas: int) -> None:
         stream_name = "TSPI"
-        subjects = ["tspi.>", f"{COMMAND_SUBJECT_PREFIX}.>", "tags.>"]
+        subjects = normalize_stream_subjects(["tspi.>", f"{COMMAND_SUBJECT_PREFIX}.>", "tags.>"])
         try:
             await js.stream_info(stream_name)
-            await js.update_stream({"name": stream_name, "subjects": subjects, "num_replicas": replicas})
+            await js.update_stream(
+                {"name": stream_name, "subjects": subjects, "num_replicas": replicas}
+            )
         except NotFoundError:
             await js.add_stream(
                 name=stream_name,

--- a/tests/test_jetstream_client.py
+++ b/tests/test_jetstream_client.py
@@ -1,0 +1,34 @@
+from tspi_kit.jetstream_client import normalize_stream_subjects
+
+
+def test_normalize_stream_subjects_removes_overlaps():
+    subjects = [
+        "tspi.>",
+        "tspi.cmd.display.>",
+        "tags.>",
+        "tspi.cmd.display.units",
+    ]
+    assert normalize_stream_subjects(subjects) == ["tspi.>", "tags.>"]
+
+
+def test_normalize_stream_subjects_keeps_distinct_prefixes():
+    subjects = [
+        "tags.>",
+        "tags.broadcast",
+        "tags.single.*",
+        "tspi.cmd.display.>",
+        "tspi.telemetry.*",
+    ]
+    assert normalize_stream_subjects(subjects) == [
+        "tags.>",
+        "tspi.cmd.display.>",
+        "tspi.telemetry.*",
+    ]
+
+
+def test_normalize_stream_subjects_handles_wildcard_ordering():
+    subjects = [
+        "tspi.cmd.display.>",
+        "tspi.>",
+    ]
+    assert normalize_stream_subjects(subjects) == ["tspi.>"]


### PR DESCRIPTION
## Summary
- add a helper in the JetStream client to collapse redundant stream subjects produced by tail wildcards
- reuse the normalization in the demo’s stream setup so modern nats-server releases no longer reject the stream
- cover the subject normalization behaviour with dedicated unit tests

## Testing
- `pytest`
- `./run_demo.sh --duration 5` *(fails once the UI entrypoints are invoked because they are not installed in this environment; the JetStream connection now succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a82879748329a38d3b3954807bec