### PR TITLE
Update asyncpg dependency for Python 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "aiofiles>=24.1.0",
-    "asyncpg>=0.29.0",
+    "asyncpg>=0.30.0",
     "cbor2>=5.7.0",
     "dpkt>=1.9.8",
     "jsonschema>=4.25.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiofiles==24.1.0
     # via low-latency-stream-kit (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
-asyncpg==0.29.0
+asyncpg==0.30.0
     # via low-latency-stream-kit (TimescaleDB persistence)
 attrs==25.3.0
     # via


### PR DESCRIPTION
## Summary
- bump asyncpg requirement to 0.30.0 to pick up Python 3.13 compatibility fixes
- align pinned requirements file with the new minimum version

## Testing
- python -m pip install asyncpg==0.30.0

------
https://chatgpt.com/codex/tasks/task_e_68d9b2ac4e54832990708f808928c880