### PR TITLE
Ensure Flet demo apps use distinct ports

### DIFF
--- a/command_console_flet.py
+++ b/command_console_flet.py
@@ -16,7 +16,7 @@ from tspi_kit.commands import OPS_CONTROL_SUBJECT
 from tspi_kit.jetstream_client import JetStreamConsumerAdapter, JetStreamThreadedClient
 from tspi_kit.tags import TagPayload, TagSender
 from tspi_kit.ui.command_console import ClientPresence, ClientPresenceTracker, OperatorEvent
-from tspi_kit.ui.flet_app import _ensure_flet
+from tspi_kit.ui.flet_app import _ensure_flet, pick_flet_web_port
 from tspi_kit.ui.player import connect_in_memory
 from tspi_kit.ui.signals import Signal
 
@@ -628,7 +628,7 @@ def main(argv: List[str] | None = None) -> int:
         page.on_close = _cleanup
         page.on_disconnect = _cleanup
 
-    ft.app(target=_launch)
+    ft.app(target=_launch, port=pick_flet_web_port())
     app = console_holder.get("app")
     if app is not None:
         app.shutdown()

--- a/player_flet.py
+++ b/player_flet.py
@@ -11,7 +11,7 @@ from tspi_kit.jetstream_client import JetStreamThreadedClient
 from tspi_kit.receiver import CompositeTSPIReceiver, TSPIReceiver
 from tspi_kit.tags import TagSender
 from tspi_kit.ui import HeadlessPlayerRunner, UiConfig
-from tspi_kit.ui.flet_app import PlayerViewConfig, mount_player
+from tspi_kit.ui.flet_app import PlayerViewConfig, mount_player, pick_flet_web_port
 from tspi_kit.ui.player import ReceiverFactory, connect_in_memory
 
 
@@ -166,7 +166,7 @@ def main(argv: list[str] | None = None) -> int:
     def _launch(page: ft.Page) -> None:
         mount_player(page, sources, config=view_config)
 
-    ft.app(target=_launch)
+    ft.app(target=_launch, port=pick_flet_web_port())
     cleanup()
     return 0
 

--- a/tspi_generator_flet.py
+++ b/tspi_generator_flet.py
@@ -12,7 +12,7 @@ from tspi_kit.commands import COMMAND_SUBJECT_PREFIX
 from tspi_kit.generator import FlightConfig, TSPIFlightGenerator
 from tspi_kit.producer import TSPIProducer
 from tspi_kit.ui import GeneratorController
-from tspi_kit.ui.flet_app import _ensure_flet
+from tspi_kit.ui.flet_app import _ensure_flet, pick_flet_web_port
 from tspi_kit.ui.player import connect_in_memory
 
 
@@ -290,7 +290,7 @@ def main(argv: list[str] | None = None) -> int:
         page.on_close = _cleanup
         page.on_disconnect = _cleanup
 
-    ft.app(target=_launch)
+    ft.app(target=_launch, port=pick_flet_web_port())
     app = app_holder.get("app")
     if app is not None:
         app.shutdown()


### PR DESCRIPTION
## Summary
- add a utility to reserve an available TCP port before launching a Flet web server so multiple apps can run together
- update the generator, player, and command console launchers to request unique ports when starting Flet

## Testing
- ./run_demo.sh --duration 1

------
https://chatgpt.com/codex/tasks/task_e_68d9b58106948329845c0ad06d2f709b